### PR TITLE
Uncomment GIT REF and GIT SOURCE from docker compose YAML.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,8 @@ services:
       - APP_HOSTNAME=${APP_HOSTNAME:-www.planet4.test}
       - APP_HOSTPATH=${APP_HOSTPATH:-}
       # - DELETE_EXISTING_FILES=false
-      # - GIT_REF=develop
-      # - GIT_SOURCE=https://github.com/greenpeace/planet4-base-fork
+      - GIT_REF=develop
+      - GIT_SOURCE=https://github.com/greenpeace/planet4-base-fork
       # - MERGE_REF=develop
       # - MERGE_SOURCE=https://github.com/greenpeace/planet4-flibble
       - NEWRELIC_LICENSE=${NEWRELIC_LICENSE:-false}


### PR DESCRIPTION
This just uncomments two Git related lines from docket-compose.yml to avoid network problems while building the dev environment.

Related issue: #8 