### PR TITLE
Remove Sysctl call and run ElasticSearch in dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ On first launch, the container bootstraps the installation with composer then af
 
 When you see the line `Starting service: openresty` you can navigate to: [https://www.planet4.test](https://www.planet4.test).
 
-If at any point the install process fails, with Compose showing a message such as `file could not be downloaded (HTTP/1.1 404 Not Found)`, this is a transient network error and re-running the install should fix the issue.
+**Troubleshooting**
+
+If at any point the install process fails, with Composer showing a message such as `file could not be downloaded (HTTP/1.1 404 Not Found)`, this is a transient network error and re-running the install should fix the issue.
 
 ### Run
 
@@ -166,6 +168,15 @@ make pmapass
 Download the latest sql file of default content: [v0.1.17.sql.gz](https://storage.googleapis.com/planet4-default-content/planet4-defaultcontent_wordpress-v0.1.17.sql.gz).
 
 Login to phpmyadmin, as described above, to import it. Select the `planet4_dev` database and go to *Import*.
+
+**Troubleshooting**
+
+In case you find any trouble importing, try doing a clean restore by removing the database. To do so in phpMyAdmin,
+select the `planet4_dev` database, go to *Operations* and click on the "Delete database (DROP)" button.
+
+Then, create a new database named `planet4_dev` using the "New" link in phpMyAdmin's sidebar. Use collation: `utf8_general_ci`.
+
+Once the empty database is created, you can try importing the default content again.
 
 ### Create Wordpress admin user
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,8 @@ services:
     image: gcr.io/planet-4-151612/elasticsearch:${ELASTICSEARCH_BUILD_TAG:-latest}
     networks:
       - local
+    environment:
+      - discovery.type=single-node
     labels:
       traefik.enable: "false"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,8 @@ services:
       - APP_HOSTNAME=${APP_HOSTNAME:-www.planet4.test}
       - APP_HOSTPATH=${APP_HOSTPATH:-}
       # - DELETE_EXISTING_FILES=false
-      # - GIT_REF=develop
-      # - GIT_SOURCE=https://github.com/greenpeace/planet4-base-fork
+      - GIT_REF=develop
+      - GIT_SOURCE=https://github.com/greenpeace/planet4-base-fork
       # - MERGE_REF=develop
       # - MERGE_SOURCE=https://github.com/greenpeace/planet4-flibble
       - NEWRELIC_LICENSE=${NEWRELIC_LICENSE:-false}

--- a/go
+++ b/go
@@ -5,9 +5,6 @@ SCALE_OPENRESTY=${SCALE_OPENRESTY:-1}
 SCALE_APP=${SCALE_APP:-1}
 PROJECT=${PROJECT:-$(basename ${PWD} | sed s/[\w.-]//g)}
 
-# Ensure Elasticsearch has adequate resources
-sudo sysctl -w vm.max_map_count=262144
-
 touch acme.json
 chmod 600 acme.json
 


### PR DESCRIPTION
Removing a `sysctl` call for allocation resources on the `go` script.

Related issued: #7 