### PR TITLE
Fix <nil> APP_HOSTPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,12 @@ DEFAULTCONTENT_IMAGE_VERSION ?= 1-25
 
 SCALE_OPENRESTY ?=1
 SCALE_APP ?=1
-
+APP_HOSTPATH        ?= test
+# YAML interprets 'empty' values as 'nil'
+ifeq ($(APP_HOSTPATH),<nil>)
+# So if APP_HOSTPATH is set, but blank, clean this value
+APP_HOSTPATH :=
+endif
 DOCKER_COMPOSE_FILE ?= docker-compose.yml
 
 MYSQL_USER := $(shell grep MYSQL_USER db.env | cut -d'=' -f2)


### PR DESCRIPTION
Running codeception-as-job with the values 
```
      APP_HOSTNAME: www.planet4.test
      APP_HOSTPATH:
```
was creating a site where all internal urls were `www.planet4.test/<nil>/`
Blatantly stealing the solution from the [similar commit on planet4-builder](https://github.com/greenpeace/planet4-builder/commit/4a12e3676daf7a34e415c78369cacfafc9373677)

Doing a Pull Request vs codeception, since I based the branch on it.