### PR TITLE
Add NRO commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ defaultcontent
 persistence
 secrets
 db/Dockerfile
+Makefile.include

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ ifeq ($(APP_HOSTPATH),<nil>)
 APP_HOSTPATH :=
 endif
 DOCKER_COMPOSE_FILE ?= docker-compose.yml
+DOCKER_COMPOSE_TOOLS_FILE ?= docker-compose.tools.yml
 
 MYSQL_USER := $(shell grep MYSQL_USER db.env | cut -d'=' -f2)
 MYSQL_PASS := $(shell grep MYSQL_PASSWORD db.env | cut -d'=' -f2)
@@ -425,7 +426,7 @@ nro-disable:
 nro-test-codeception:
 	@docker-compose \
 		-f $(DOCKER_COMPOSE_FILE) \
-		-f docker-compose.tools.yml \
+		-f $(DOCKER_COMPOSE_TOOLS_FILE) \
 		run \
 		-e APP_HOSTNAME=$(NRO_APP_HOSTNAME) \
 		-e APP_HOSTPATH=$(NRO_APP_HOSTPATH) \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# include optional configuration (used for NRO configuration)
+-include Makefile.include
+
 SHELL := /bin/bash
 
 CONTENT_DB_VERSION ?= 0.1.38
@@ -117,6 +120,12 @@ endif
 	@circleci config validate >/dev/null
 
 # ============================================================================
+
+ifdef NRO_REPO
+# gives us the basename of the repo e.g. "planet4-netherlands"
+NRO_DIRNAME := $(shell echo $(NRO_REPO) | sed 's/^.*\///g; s/\.git$$//g')
+NRO_BRANCH ?= develop
+endif
 
 .PHONY: env
 env:
@@ -368,3 +377,52 @@ revertdb:
 	@docker rm $(shell $(COMPOSE_ENV) docker-compose ps -q db)
 	@docker volume rm $(COMPOSE_PROJECT_NAME)_db
 	@docker-compose up -d
+
+.PHONY: nro-enable
+nro-enable:
+	@[[ ! -z "$(NRO_REPO)" ]] || (\
+		echo "You need to specify some variables before you can use this!" && \
+		echo && \
+		echo "Create/edit a file called Makefile.include, then add:" && \
+		echo && \
+		echo "NRO_REPO := <put the Git URL for the NRO repo here>" && \
+		echo "NRO_THEME := <put the theme name for the NRO here>" && \
+		echo "NRO_BRANCH := <optionally, the branch you want, default is develop>" && \
+		echo && \
+		exit 1 \
+	)
+	@echo "NRO repo $(NRO_REPO)"
+	@echo "NRO theme $(NRO_THEME)"
+	@echo "NRO dirname $(NRO_DIRNAME)"
+	@docker-compose exec php-fpm sh -c " \
+		mkdir -p sites && \
+		(cd sites && (test -d $(NRO_DIRNAME) || git clone $(NRO_REPO) $(NRO_DIRNAME))) && \
+		(cd "sites/$(NRO_DIRNAME)" && git checkout $(NRO_BRANCH)) && \
+		composer config extra.merge-plugin.require "sites/$(NRO_DIRNAME)/composer-local.json" && \
+		composer update && \
+		composer run-script copy:themes && \
+		composer run-script copy:plugins && \
+		composer run-script plugin:activate  && \
+		composer run-script theme:activate $(NRO_THEME) \
+	"
+	@make flush
+
+.PHONY: nro-disable
+nro-disable:
+	@docker-compose exec php-fpm sh -c " \
+		composer config extra.merge-plugin.require "composer-local.json" && \
+		composer update && \
+		composer run-script copy:themes && \
+		composer run-script copy:plugins && \
+		composer run-script plugin:activate  && \
+		composer run-script theme:activate planet4-master-theme \
+	"
+	@make flush
+
+.PHONY: nro-test-codeception
+nro-test-codeception:
+	@docker-compose exec php-fpm sh -c 'cd tests && composer install --prefer-dist --no-progress'
+	@docker-compose exec php-fpm sh -c '\
+		cd sites/$(NRO_DIRNAME) && \
+		../../tests/vendor/bin/codecept run --xml=junit.xml --html \
+	'

--- a/README.md
+++ b/README.md
@@ -245,6 +245,42 @@ See [TESTING](TESTING.md) for more info.
 
 ---
 
+## NRO sites
+
+You can also use this setup to work on an NRO site.
+
+**First, create/edit `Makefile.include`** to contain:
+
+```
+NRO_REPO := https://github.com/greenpeace/planet4-netherlands.git
+NRO_THEME := planet4-child-theme-netherlands
+
+# optionally specify a branch, will default to "develop" otherwise
+#NRO_BRANCH := my-other-branch
+
+# by default it will test against your local docker-compose setup version
+# but you can optionally specify these variables to run the tests against
+# a deployed environment
+#NRO_APP_HOSTNAME := k8s.p4.greenpeace.org
+#NRO_APP_HOSTPATH := nl
+```
+
+**Then enable the NRO:**
+
+```
+make nro-enable
+```
+
+**And, run the tests:**
+
+```
+make nro-test-codeception
+```
+
+The tests work a bit differently to the main ones, see [TESTING#NRO](TESTING.md#NRO) for more info.
+
+---
+
 ## Configuration
 
 ### Configuring WP-Stateless GCS bucket storage

--- a/TESTING.md
+++ b/TESTING.md
@@ -227,3 +227,15 @@ export OPENRESTY_IMAGE=gcr.io/planet-4-151612/planet4-base-openresty:codeception
 export APP_IMAGE=gcr.io/planet-4-151612/planet4-base-app:codeception
 make ci
 ```
+
+## NRO
+
+The NRO-specific tests are a simplified version of the main tests. In particular:
+
+- only one suite (an acceptance suite named "tests")
+- mainly designed to run against the gcloud deployed environments
+- NRO repos contain no codeception configuration, only a `tests/` directory, with the tests directly in
+- when executed the codeception configuration is copied into the directory
+- configuration and dependencies are defined in [greenpeace/planet4-circleci-codeception](https://github.com/greenpeace/planet4-circleci-codeception)
+- `codeceptionify.sh <destination>` script copies the needed configuration files into `<destination>`
+- only base codeception modules are available (i.e. nothing from [lucatume/wp-browser](https://github.com/lucatume/wp-browser)) - so no direct db access or content seeding

--- a/docker-compose.tools.yml
+++ b/docker-compose.tools.yml
@@ -1,0 +1,18 @@
+---
+version: '3'
+services:
+  codeception:
+    image: gcr.io/planet-4-151612/p4-codeception:develop
+    working_dir: /app/source
+    command: /bin/false  # only needed when running specific commands
+    environment:
+      - APP_HOSTNAME=${APP_HOSTNAME:-www.planet4.test}
+      - APP_HOSTPATH=${APP_HOSTPATH:-}
+      - CODECEPTION_SELENIUM_HOST=selenium
+      - CODECEPTION_SELENIUM_PORT=4444
+    networks:
+      - local
+    volumes:
+      - ./persistence/app:/app/source:cached
+    labels:
+      traefik.enable: "false"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,9 @@ services:
       - WP_STATELESS_MEDIA_BUCKET=${APP_HOSTNAME:-www-planet4-test}
       - WP_STATELESS_MEDIA_ENABLED=${WP_STATELESS_MEDIA_ENABLED:-true}
       # - WP_VERSION=${WP_VERSION:-latest}
+      - WP_DEFAULT_CONTENT=false
+      - CODECEPTION_SELENIUM_HOST=selenium
+      - CODECEPTION_SELENIUM_PORT=4444
     env_file:
       - ./app.env
       - ./db.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,6 @@ services:
       - WP_STATELESS_MEDIA_BUCKET=${APP_HOSTNAME:-www-planet4-test}
       - WP_STATELESS_MEDIA_ENABLED=${WP_STATELESS_MEDIA_ENABLED:-true}
       # - WP_VERSION=${WP_VERSION:-latest}
-      - WP_DEFAULT_CONTENT=false
       - CODECEPTION_SELENIUM_HOST=selenium
       - CODECEPTION_SELENIUM_PORT=4444
     env_file:


### PR DESCRIPTION
This adds some extra Makefile commands useful for working with NRO sites and their tests.

**First, create/edit `Makefile.include`** to contain:

```
NRO_REPO := https://github.com/greenpeace/planet4-netherlands.git
NRO_THEME := planet4-child-theme-netherlands

# optionally specify a branch, will default to "develop" otherwise
NRO_BRANCH := add-tests

# by default it will test against your local docker-compose setup version
# but you can optionally specify these variables to run the tests against
# a deployed environment
#NRO_APP_HOSTNAME := k8s.p4.greenpeace.org
#NRO_APP_HOSTPATH := nl
```

**Then enable the NRO:**
```
make nro-enable
```

This:
* checks out the NRO repo into `persistence/sites/<repo name>`
* switches to branch NRO_BRANCH (or default `develop`)
* configures the correct composer merge require
* runs composer update
* copies themes / plugins
* activates all plugins
* activates NRO_THEME
* cache flush

**And run it's tests:**
```
make nro-test-codeception
```
This:
* runs the tests in `persistence/sites/<repo name>/tests` against the local docker-compose env
* uses the codeception configuration and dependencies from [greenpeace/planet4-circleci-codeception](https://github.com/greenpeace/planet4-circleci-codeception)

**Then revert to the non-NRO mode:**
```
make nro-disable
```

This:
* resets the composer merge plugin require to `composer-local.json`
* re-runs the composer update / copying / etc
* switches theme to planet4-master-theme
* cache flush

Currently works in conjunction with https://github.com/greenpeace/planet4-netherlands/pull/1