### PR TITLE
Fix php-shell target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ flush:
 
 .PHONY: php-shell
 php-shell:
-	@docker-compose run --rm --no-deps php-fpm bash
+	@docker-compose exec php-fpm bash
 
 .PHONY: revertdb
 revertdb:


### PR DESCRIPTION
Change php-shell target to use existing php-fpm container and don't create a new one