### PR TITLE
Replace yarn with npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Firstly, check you have all the requirements on your system. For Linux users, th
 * [git](https://www.git-scm.com/downloads)
 * [make](https://www.gnu.org/software/make/) - Instructions for installing make vary, for OSX users `xcode-select --install` might work.
 * [docker](https://docs.docker.com/engine/installation/)
-* [yarn](https://yarnpkg.com/)
-* [gulp](https://gulpjs.com/)
+* [npm](https://www.npmjs.com/)
+* [gulp-cli](https://gulpjs.com/)
 * [shellcheck](https://www.shellcheck.net/)
 * [yamllint](http://www.yamllint.com/)
 * [jq](https://stedolan.github.io/jq/)
@@ -168,7 +168,7 @@ These folders would be turned into the respective git repositories.
 > - persistence/app/public/wp-content/themes/planet4-master-theme
 > - persistence/app/public/wp-content/plugins/planet4-plugin-blocks
 > - persistence/app/public/wp-content/plugins/planet4-plugin-engagingnetworks
-> - persistence/app/public/wp-content/plugins/planet4-plugin-medialibrary 
+> - persistence/app/public/wp-content/plugins/planet4-plugin-medialibrary
 
 ```
 make dev

--- a/watch.sh
+++ b/watch.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 set -eao pipefail
 
-[ -x "$(command -v yarn)" ] || { >&2 echo "yarn is required but not installed, exiting."; exit 1; }
-[ -x "$(command -v gulp)" ] || { >&2 echo "gulp is requited but not installed, exiting."; exit 1; }
+[ -x "$(command -v npm)" ] || { >&2 echo "npm is required but not installed, exiting."; exit 1; }
+[ -x "$(command -v gulp)" ] || { >&2 echo "gulp-cli is requited but not installed, exiting."; exit 1; }
 
 pushd persistence/app/public/wp-content/themes/planet4-master-theme
-yarn
+npm install
 gulp watch&
 popd
 
 pushd persistence/app/public/wp-content/plugins/planet4-plugin-blocks
-yarn
+npm install
 gulp watch&
 popd
 


### PR DESCRIPTION
We no longer use yarn on our code repositories. We switched to npm.

Make it more clear that is gulp-cli specfically that needs to be installed system-wide.