### PR TITLE
Pin selenium/standalone-chrome v3.141.59-oxygen

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -77,7 +77,7 @@ services:
       - local
 
   selenium:
-    image: selenium/standalone-chrome:3
+    image: selenium/standalone-chrome:3.141.59-oxygen
     shm_size: 512M
     networks:
       - local


### PR DESCRIPTION
Pin selenium/standalone-chrome v3.141.59-oxygen to address the error unknown command (w3c)

Latest selenium/standalone-chrome (3.141.59-palladium) with ChromeDriver v75.x and Chrome v75.x introduces an error 
`unknown command: Cannot call non W3C standard command while in W3C mode`

https://hub.docker.com/r/selenium/standalone-chrome/tags
https://stackoverflow.com/questions/56452798/how-to-turn-off-w3c-in-chromedriver-to-address-the-error-unknown-command-cannot