### PR TITLE
Amend dev script to fully clone

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -8,7 +8,7 @@ else
   GIT_DOMAIN="https://github.com/"
 fi
 
-git clone --depth=1 --shallow-submodules --recurse-submodules ${GIT_DOMAIN}greenpeace/planet4-master-theme.git persistence/app/public/wp-content/themes/planet4-master-theme
+git clone --recurse-submodules ${GIT_DOMAIN}greenpeace/planet4-master-theme.git persistence/app/public/wp-content/themes/planet4-master-theme
 pushd persistence/app/public/wp-content/themes/planet4-master-theme
 npm install
 gulp git_hooks
@@ -17,7 +17,7 @@ popd
 
 for plugin in blocks engagingnetworks medialibrary
 do
-  git clone --depth=1 --shallow-submodules --recurse-submodules ${GIT_DOMAIN}greenpeace/planet4-plugin-${plugin}.git persistence/app/public/wp-content/plugins/planet4-plugin-${plugin}
+  git clone --recurse-submodules ${GIT_DOMAIN}greenpeace/planet4-plugin-${plugin}.git persistence/app/public/wp-content/plugins/planet4-plugin-${plugin}
   pushd persistence/app/public/wp-content/plugins/planet4-plugin-${plugin}
   npm install
   gulp git_hooks


### PR DESCRIPTION
The `--depth=1` limits the available branches to just the default one (develop), when fetching.

remotes on `.git-config` with `--depth=1`:
```
[remote "origin"]
        url = git@github.com:greenpeace/planet4-plugin-medialibrary.git
        fetch = +refs/heads/develop:refs/remotes/origin/develop
```
without `--depth=1`:
```
[remote "origin"]
        url = git@github.com:greenpeace/planet4-plugin-medialibrary.git
        fetch = +refs/heads/*:refs/remotes/upstream/*
```