### PR TITLE
PLANET-3655 Add Makefile target to install and configure xdebug

### DIFF
--- a/dev-templates/xdebug.tmpl
+++ b/dev-templates/xdebug.tmpl
@@ -1,0 +1,9 @@
+zend_extension=xdebug.so
+xdebug.remote_host=${XDEBUG_REMOTE_HOST}
+xdebug.remote_port=9010
+xdebug.remote_enable=1
+xdebug.remote_handler=dbgp
+xdebug.profiler_enable=0;
+xdebug.profiler_enable_trigger=1;
+xdebug.profiler_output_dir="/app/source"
+xdebug.profiler_output_name="cachegrind.out.%t-%s-%R"


### PR DESCRIPTION
I did not find a reliable way to get ip address in mac without introducing a new system dependency.
It uses the ip address of the first interface of the system (hopefully).
`$ ipconfig getifaddr en0`

Tried also some variants of docker macos specific dns names but did not work.
`host.docker.internal`
`docker.for.mac.localhost`
`docker.for.mac.host.localhost`
Although I could ping some of them, I could not make them connect to dbpg.
https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds

Also tried `xdebug.remote_connect_back` to get rid of `xdebug.remote_host`, but didn't work out either.