### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -26,7 +26,7 @@ The default content is imported automatically for you.
 
 **Troubleshooting**
 
-If you want to revert back to the default content database you can delete the remove the database container and volume and recreate:
+If you want to revert back to the default content database you can delete the database container and volume and recreate:
 
 ```bash
 make revertdb
@@ -117,14 +117,14 @@ This docker environment relies on the mysql official image as well as on the [pl
 
 Both images provide environment variables which adjust aspects of the runtime configuration. For this environment to run only the database parameters such as hostname, database name, database users and passwords are required.
 
-Initial values for this environment variables are dummy but are good to go for development porpoises. They can be changed in the provided `app.env` and `db.env` files, or directly in the [docker-compose.yml](https://docs.docker.com/compose/compose-file/#environment) file itself.
+Initial values for this environment variables are dummy but are good to go for development purposes. They can be changed in the provided `app.env` and `db.env` files, or directly in the [docker-compose.yml](https://docs.docker.com/compose/compose-file/#environment) file itself.
 
 ### Some useful variables
 
 See [openresty-php-exim](https://github.com/greenpeace/planet4-docker/tree/develop/source/planet-4-151612/openresty-php-exim)
 
 -   `NEWRELIC_LICENSE` set to the license key in your NewRelic dashboard to automatically receive server and application metrics
--   `PHP_MEMORY_LIMIT` maximum memory each PHP process can consume before being termminated and restarted by the scheduler
+-   `PHP_MEMORY_LIMIT` maximum memory each PHP process can consume before being terminated and restarted by the scheduler
 -   `PHP_XDEBUG_REMOTE_HOST` in development mode enables remote [XDebug](https://xdebug.org/) debugging, tracing and profiling
 
 ### Development mode
@@ -140,7 +140,7 @@ Document some of the useful builtin configuration options available in upstream 
 
 ### Updating
 
-To ensure you're running the latest version of both the infrastructure and the application you can just build all containers again. **Keep in mind that this deletes the persistence folder and therefor all you local code changes to the application.**
+To ensure you're running the latest version of both the infrastructure and the application you can just build all containers again. **Keep in mind that this deletes the persistence folder and therefore all you local code changes to the application.**
 
 ```bash
 make build

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -77,7 +77,7 @@ cd planet4-docker-compose
 make dev
 ```
 
-If you want the aplication repositories to be cloned using ssh protocol, instead of https, you can use a variable:
+If you want the application repositories to be cloned using ssh protocol, instead of https, you can use a variable:
 
 ```bash
 GIT_PROTO="ssh" make dev
@@ -108,7 +108,7 @@ make run
 
 ### Lightweight configuration
 
-If the current setup is too heavy for your machine, there is a lighter version that skips creating some of the containers. Keep in mind though that this leaves out PhpMyAdmin, ElasticHQ and Sellenium containers, so it would be harder to debug things.
+If the current setup is too heavy for your machine, there is a lighter version that skips creating some of the containers. Keep in mind though that this leaves out PhpMyAdmin, ElasticHQ and Selenium containers, so it would be harder to debug things.
 
 To use it, you need to set the relevant environmental variable. For instance:
 


### PR DESCRIPTION
Fixed a few typos in `/docs`