### PR TITLE
Changed documentation to use Node.js version 14

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,7 @@ sudo apt install -y curl git make
 sudo apt install -y composer php-xml php-mbstring
 
 # install node and npm
-curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 sudo apt install -y nodejs
 
 # install docker


### PR DESCRIPTION
Node.js version 13 isn't supported anymore, so installing v14 makes more sense now.