### PR TITLE
PLANET-4998 Add code coverage option to tests

### DIFF
--- a/dev-templates/pcov.ini
+++ b/dev-templates/pcov.ini
@@ -1,0 +1,3 @@
+extension=pcov.so
+pcov.enabled=1
+pcov.directory=/app/source/public/wp-content

--- a/dev-templates/probed_index.php
+++ b/dev-templates/probed_index.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Front to the WordPress application. This file doesn't do anything, but loads
+ * wp-blog-header.php which does and tells WordPress to load the theme.
+ *
+ * @package WordPress
+ */
+
+include '../tests/c3.php';
+
+/**
+ * Tells WordPress to load the WordPress theme and output it.
+ *
+ * @var bool
+ */
+define( 'WP_USE_THEMES', true );
+
+/** Loads the WordPress Environment and Template */
+require __DIR__ . '/wp-blog-header.php';

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -23,6 +23,7 @@ services:
     networks:
       - local
       - db
+      - proxy
     dns:
       - ${DNS_RESOLVER:-1.1.1.1}
     environment:


### PR DESCRIPTION
* Also give proxy network to php-fpm container, so that the coverage
requests can work.
* Move c3.php after installing codeception.
* Add `php-pcov` for coverage collection in CI.