### PR TITLE
PLANET-5059: Split local development volumes

### DIFF
--- a/docker-compose.split.yml
+++ b/docker-compose.split.yml
@@ -1,0 +1,158 @@
+---
+version: '3'
+services:
+  traefik:
+    image: traefik:1.7
+    command: --web --docker --docker.domain=planet4.test --docker.watch
+    networks:
+      proxy:
+        aliases:
+          - ${APP_HOSTNAME:-www.planet4.test}
+          - www.planet4.fnord
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./traefik.toml:/traefik.toml
+    labels:
+      traefik.backend: "traefik"
+      traefik.frontend.rule: "Host:traefik.${APP_HOSTNAME:-www.planet4.test}"
+      traefik.docker.network: "planet4dockercompose_proxy"
+      traefik.enable: "true"
+
+  redis:
+    image: redis:4-stretch
+    networks:
+      - local
+    labels:
+      traefik.enable: "false"
+
+  db:
+    build:
+      context: defaultcontent
+      dockerfile: ../db/Dockerfile
+    env_file:
+      - ./db.env
+    volumes:
+      - db:/var/lib/mysql
+    networks:
+      - db
+    labels:
+      traefik.enable: "false"
+
+  php-fpm:
+    image: ${APP_IMAGE:-gcr.io/planet-4-151612/wordpress:planet-5158}
+    depends_on:
+      - db
+      - redis
+    networks:
+      - local
+      - db
+      - proxy
+    dns:
+      - ${DNS_RESOLVER:-1.1.1.1}
+    volumes:
+      - ./secrets/wp-stateless-media-key.json:/app/secrets/wp-stateless-media-key.json:ro
+      - ${LOCAL_APP_PATH:-./persistence/app}:/app/source:cached
+      - ${LOCAL_P4MT_PATH:-./persistence/app/public/wp-content/themes/planet4-master-theme}:/app/source/public/wp-content/themes/planet4-master-theme:consistent
+      - ${LOCAL_P4GBKS_PATH:-./persistence/app/public/wp-content/plugins/planet4-plugin-gutenberg-blocks}:/app/source/public/wp-content/plugins/planet4-plugin-gutenberg-blocks:consistent
+      - ${LOCAL_P4GEN_PATH:-./persistence/app/public/wp-content/plugins/planet4-plugin-gutenberg-engagingnetworks}:/app/source/public/wp-content/plugins/planet4-plugin-gutenberg-engagingnetworks:consistent
+      - ${LOCAL_UPLOAD_PATH:-./persistence/app/public/wp-content/uploads}:/app/source/public/wp-content/uploads:cached
+    environment:
+      - APP_ENV=${APP_ENV:-develop}
+      - APP_HOSTNAME=${APP_HOSTNAME:-www.planet4.test}
+      - APP_HOSTPATH=${APP_HOSTPATH:-}
+      # - DELETE_EXISTING_FILES=false
+      - GIT_REF=${GIT_REF:-develop}
+      - GIT_SOURCE=https://github.com/greenpeace/planet4-base-fork
+      # - MERGE_REF=develop
+      # - MERGE_SOURCE=https://github.com/greenpeace/planet4-flibble
+      - NEWRELIC_LICENSE=${NEWRELIC_LICENSE:-false}
+      # - OVERWRITE_EXISTING_FILES=false
+      - WP_FORCE_SSL_ADMIN=false
+      - WP_REDIS_ENABLED=${WP_REDIS_ENABLED:-true}
+      - WP_STATELESS_MEDIA_BUCKET=${APP_HOSTNAME:-www-planet4-test}
+      - WP_STATELESS_MEDIA_ENABLED=${WP_STATELESS_MEDIA_ENABLED:-true}
+      # - WP_VERSION=${WP_VERSION:-latest}
+      - CODECEPTION_SELENIUM_HOST=selenium
+      - CODECEPTION_SELENIUM_PORT=4444
+      - LOCAL_APP_PATH=${LOCAL_APP_PATH:-./persistence/app}
+      - LOCAL_P4MT_PATH=${LOCAL_P4MT_PATH:-./persistence/app/public/wp-content/themes/planet4-master-theme}
+      - LOCAL_P4GBKS_PATH=${LOCAL_P4GBKS_PATH:-./persistence/app/public/wp-content/plugins/planet4-plugin-gutenberg-blocks}
+      - LOCAL_P4GEN_PATH=${LOCAL_P4GEN_PATH:-./persistence/app/public/wp-content/plugins/planet4-plugin-gutenberg-engagingnetworks}
+      - LOCAL_UPLOAD_PATH=${LOCAL_UPLOAD_PATH:-./persistence/app/public/wp-content/uploads}
+    env_file:
+      - ./app.env
+      - ./db.env
+    labels:
+      traefik.enable: "false"
+
+  openresty:
+    image: ${OPENRESTY_IMAGE:-gcr.io/planet-4-151612/openresty:develop}
+    depends_on:
+      - php-fpm
+      - traefik
+      - redis
+    networks:
+      - local
+      - proxy
+    volumes:
+      - ${LOCAL_APP_PATH:-./persistence/app}:/app/source:cached
+      - ${LOCAL_P4MT_PATH:-./persistence/app/public/wp-content/themes/planet4-master-theme}:/app/source/public/wp-content/themes/planet4-master-theme:consistent
+      - ${LOCAL_P4GBKS_PATH:-./persistence/app/public/wp-content/plugins/planet4-plugin-gutenberg-blocks}:/app/source/public/wp-content/plugins/planet4-plugin-gutenberg-blocks:consistent
+      - ${LOCAL_P4GEN_PATH:-./persistence/app/public/wp-content/plugins/planet4-plugin-gutenberg-engagingnetworks}:/app/source/public/wp-content/plugins/planet4-plugin-gutenberg-engagingnetworks:consistent
+      - ${LOCAL_UPLOAD_PATH:-./persistence/app/public/wp-content/uploads}:/app/source/public/wp-content/uploads:cached
+    environment:
+      - APP_ENV=${APP_ENV:-develop}
+      - PAGESPEED_ENABLED=${PAGESPEED_ENABLED:-false}
+      - APP_HOSTNAME=${APP_HOSTNAME:-www.planet4.test}
+      - APP_HOSTPATH=${APP_HOSTPATH:-}
+      - REDIS_FASTCGI_CACHE_ENABLED=true
+      - PHP_ENABLED=true
+      - LOCAL_APP_PATH=${LOCAL_APP_PATH:-./persistence/app}
+      - LOCAL_P4MT_PATH=${LOCAL_P4MT_PATH:-./persistence/app/public/wp-content/themes/planet4-master-theme}
+      - LOCAL_P4GBKS_PATH=${LOCAL_P4GBKS_PATH:-./persistence/app/public/wp-content/plugins/planet4-plugin-gutenberg-blocks}
+      - LOCAL_P4GEN_PATH=${LOCAL_P4GEN_PATH:-./persistence/app/public/wp-content/plugins/planet4-plugin-gutenberg-engagingnetworks}
+      - LOCAL_UPLOAD_PATH=${LOCAL_UPLOAD_PATH:-./persistence/app/public/wp-content/uploads}
+    labels:
+      - "traefik.backend=test"
+      - "traefik.foo.frontend.rule=Host:${APP_HOSTNAME:-www.planet4.test}"
+      - "traefik.bar.frontend.rule=Host:www.planet4.fnord"
+      - "traefik.docker.network=planet4dockercompose_proxy"
+      - "traefik.enable=true"
+    
+  elasticsearch:
+    image: gcr.io/planet-4-151612/elasticsearch:${ELASTICSEARCH_BUILD_TAG:-latest}
+    networks:
+      - local
+    environment:
+      - discovery.type=single-node
+    labels:
+      traefik.enable: "false"
+
+  selenium:
+    image: selenium/standalone-chrome-debug:3
+    environment:
+      - VNC_NO_PASSWORD=1
+    ports:
+      - "5900:5900"
+    volumes:
+      - /dev/shm:/dev/shm
+    networks:
+      - local
+      - proxy
+      - db
+    labels:
+      traefik.enable: "false"
+
+networks:
+  local:
+  db:
+  proxy:
+    driver: bridge
+
+volumes:
+  db:
+  pma:

--- a/go.sh
+++ b/go.sh
@@ -9,10 +9,10 @@ touch acme.json
 chmod 600 acme.json
 
 echo "Building services ..."
-docker-compose -p "${PROJECT}" -f "${DOCKER_COMPOSE_FILE:-docker-compose.yml}" build
+docker-compose --verbose -p "${PROJECT}" -f "${DOCKER_COMPOSE_FILE:-docker-compose.yml}" build
 
 echo "Starting services ..."
-docker-compose -p "${PROJECT}" -f "${DOCKER_COMPOSE_FILE:-docker-compose.yml}" up -d \
+docker-compose --verbose -p "${PROJECT}" -f "${DOCKER_COMPOSE_FILE:-docker-compose.yml}" up -d \
   --remove-orphans \
   --scale openresty="$SCALE_OPENRESTY" \
   --scale php-fpm="$SCALE_APP"

--- a/repos.sh
+++ b/repos.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ea
+set -eax
 
 if [[ $GIT_PROTO = "ssh" ]]
 then
@@ -8,9 +8,31 @@ else
   GIT_DOMAIN="https://github.com/"
 fi
 
-git clone --recurse-submodules ${GIT_DOMAIN}greenpeace/planet4-master-theme.git persistence/app/public/wp-content/themes/planet4-master-theme
+LOCAL_P4MT_PATH=${LOCAL_P4MT_PATH:-./persistence/app/public/wp-content/themes/planet4-master-theme}
+LOCAL_P4GBKS_PATH=${LOCAL_P4GBKS_PATH:-./persistence/app/public/wp-content/plugins/planet4-plugin-gutenberg-blocks}
+LOCAL_P4GEN_PATH=${LOCAL_P4GEN_PATH:-./persistence/app/public/wp-content/plugins/planet4-plugin-gutenberg-engagingnetworks}
 
-for plugin in gutenberg-blocks gutenberg-engagingnetworks
-do
-  git clone --recurse-submodules ${GIT_DOMAIN}greenpeace/planet4-plugin-${plugin}.git persistence/app/public/wp-content/plugins/planet4-plugin-${plugin}
-done
+echo "Cloning main theme and plugins..."
+
+if [ ! -d "${LOCAL_P4MT_PATH}" ]
+then
+  git clone --recurse-submodules ${GIT_DOMAIN}greenpeace/planet4-master-theme.git "${LOCAL_P4MT_PATH}"
+else
+  git submodule update --init
+fi
+
+if [ ! -d "${LOCAL_P4GBKS_PATH}" ]
+then
+  git clone --recurse-submodules ${GIT_DOMAIN}greenpeace/planet4-plugin-gutenberg-blocks.git "${LOCAL_P4GBKS_PATH}"
+else
+  git submodule update --init
+fi
+
+if [ ! -d "${LOCAL_P4GEN_PATH}" ]
+then
+  git clone --recurse-submodules ${GIT_DOMAIN}greenpeace/planet4-plugin-gutenberg-engagingnetworks.git "${LOCAL_P4GEN_PATH}"
+else
+  git submodule update --init
+fi
+
+echo "Done."


### PR DESCRIPTION
__Do not merge__, and no need to actually review, for archive only.

## What I wanted to do

- Giving a volume to wordpress
- Giving a volume by plugin/theme, or a volume for plugins and one for themes
- Making the local structure flexible, giving choice to the developer on where to edit repos locally
- Enough parameters to be able to eventually migrate to a structure like [bedrock](https://roots.io/docs/bedrock/master/folder-structure/) does, considering wordpress as a dependency (interesting read https://roots.io/twelve-factor-wordpress/)

## What I got

- A huge mess
- Some crashes
- Some insights
- Many questions
- Unfinished business with docker-sync
  - docker-sync seems to have [far better results](https://docker-sync.readthedocs.io/en/latest/miscellaneous/performance.html) (once synced) than just splitting and configuring volumes. But the sync takes its time.

Finding the right optimization for each volume was not obvious to me; file changes made locally have to be propagated inside the container to be seen on the website, and dependencies installed by the container have to be accessible locally for autocompletion and debugging; in the end, those volumes with the most file changes often have to be consistent in both ways. The `uploads` folder could be delegated, but I had some problems mounting a delegated volume on osx (crashes, and unability to mount `/var/lib/mutagen`, apparently [`/var` should be `/private/var`](https://stackoverflow.com/a/45123074) but in this situation I'm not the one deciding of the folder of a delegated volume), and the gain would be negligible overall.  
I started another test with `docker-sync`, not yet conclusive.

## What _I think_ we need

- Less hardcoded/relative paths
  - This remark is valid in our dockerfile and scripts (more env variables), and in our plugins/themes code (we have to move from relative and hardcoded paths to configurable constants and wordpress functions)
  - For docker, this means changes in the 'Makefile', but also in `planet4-docker` where `wp-content` and public paths are sometimes hardcoded
- Move to a flat(er) structure, so that we can split volumes without having one inside the other
  - Move Wordpress to its own directory https://wordpress.org/support/article/giving-wordpress-its-own-directory/
  - Move plugins, themes and uploads in a parallel folder https://wordpress.org/support/article/editing-wp-config-php/#moving-wp-content-folder
  - Give a different volume to wordpress on one side, and content on the other (maybe a different volume for themes, plugins, uploads)
- Give choice to the developer
  - bind plugins, themes and/or uploads volumes to a user specified local folder. If it is not in `./persistence`, never delete those.