### PR TITLE
WIP Do node stuff in separate container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,8 @@ services:
       - ${DNS_RESOLVER:-1.1.1.1}
     volumes:
       - ./persistence/app:/app/source:cached
+      # Separate mount points for assets and npm which are not needed by PHP (not mapped === dir excluded from volume).
+      - /app/source/public/wp-content/themes/planet4-master-theme/node_modules/
       - ./secrets/wp-stateless-media-key.json:/app/secrets/wp-stateless-media-key.json:ro
     environment:
       - APP_ENV=${APP_ENV:-develop}
@@ -79,6 +81,40 @@ services:
       - ./db.env
     labels:
       traefik.enable: "false"
+
+  node-npm-theme:
+    image: mhart/alpine-node
+    volumes:
+      - ./persistence/app/public/wp-content/themes/planet4-master-theme:/var/workdir
+    networks:
+      - local
+    working_dir: /var/workdir
+    command: npm i
+
+
+  node-build-theme:
+    image: mhart/alpine-node
+    depends_on:
+      - node-npm-theme
+    volumes:
+      - ./persistence/app/public/wp-content/themes/planet4-master-theme:/var/workdir
+    networks:
+      - local
+    working_dir: /var/workdir
+    command: npm run build
+
+  node-watch-theme:
+    image: mhart/alpine-node
+    volumes:
+      - ./persistence/app/public/wp-content/themes/planet4-master-theme:/var/workdir
+    networks:
+      - local
+    working_dir: /var/workdir
+    command: npm start
+
+#  node-builder-plugin:
+#    image: node
+#    volumes: ./persistence/app/public/wp-content/plugins/planet4-plugin-gutenberg-blocks
 
   openresty:
     image: ${OPENRESTY_IMAGE:-gcr.io/planet-4-151612/openresty:develop}


### PR DESCRIPTION
* Seems to work fine with a lightweight image I found after a quick
search. Possibly there are even more suitable images somewhere (or we
might build a dedicated, but rather not, as those are slower in CI than
the more commonly used ones).
* Exclude node_modules and built assets from the php container. I
suppose that this decreases the load for the php-fpm container,
especially since node_modules consists of a huge amount of small files.
Though it's just an assumption and we should test this impact. If it
would be significant we can also look to do the same thing in other
directories not needed in other containers.