### PR TITLE
Fix pcov install getting stuck in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ test: install-codeception test-env-info test-codeception
 # php-pcov allows for zero overhead analysis. Codeception will automatically use it as coverage driver if it's present.
 .PHONY: install-pcov
 install-pcov:
-	docker-compose exec php-fpm sh -c 'apt-get update && apt-get install php-pcov'
+	docker-compose exec php-fpm sh -c 'apt-get update && apt-get install -y php-pcov'
 	docker cp dev-templates/pcov.ini $(shell $(COMPOSE_ENV) docker-compose ps -q php-fpm):/tmp/20-pcov.ini
 	docker-compose exec php-fpm sh -c 'cp /tmp/20-pcov.ini /etc/php/$${PHP_MAJOR_VERSION}/fpm/conf.d/20-pcov.ini'
 	docker-compose exec php-fpm sh -c 'mv /tmp/20-pcov.ini /etc/php/$${PHP_MAJOR_VERSION}/cli/conf.d/20-pcov.ini'


### PR DESCRIPTION
* This used to work without `-y`, but the package probably changed and
now the jobs get stuck without it.