### PR TITLE
Make light config the default

### DIFF
--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -72,6 +72,8 @@ services:
       - WP_STATELESS_MEDIA_BUCKET=${APP_HOSTNAME:-www-planet4-test}
       - WP_STATELESS_MEDIA_ENABLED=${WP_STATELESS_MEDIA_ENABLED:-true}
       - WP_VERSION=5.4.2
+      - CODECEPTION_SELENIUM_HOST=selenium
+      - CODECEPTION_SELENIUM_PORT=4444
     env_file:
       - ./app.env
       - ./db.env
@@ -103,12 +105,57 @@ services:
       - "traefik.docker.network=planet4dockercompose_proxy"
       - "traefik.enable=true"
 
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin:4.7
+    depends_on:
+      - db
+      - traefik
+    environment:
+      PMA_USER: root
+      PMA_PASSWORD: root
+    env_file:
+      - ./db.env
+    volumes:
+      - pma:/sessions
+    networks:
+      - db
+      - proxy
+    labels:
+      traefik.backend: "pma"
+      traefik.frontend.rule: "Host:pma.www.planet4.test"
+      traefik.docker.network: "planet4dockercompose_proxy"
+      traefik.enable: "true"
+
   elasticsearch:
     image: gcr.io/planet-4-151612/elasticsearch:${ELASTICSEARCH_BUILD_TAG:-latest}
     networks:
       - local
     environment:
       - discovery.type=single-node
+    labels:
+      traefik.enable: "false"
+
+  elastichq:
+    image: elastichq/elasticsearch-hq
+    environment:
+      HQ_DEFAULT_URL: http://elasticsearch:9200
+    networks:
+      - local
+    ports:
+      - "5000:5000"
+
+  selenium:
+    image: selenium/standalone-chrome-debug:3
+    environment:
+      - VNC_NO_PASSWORD=1
+    ports:
+      - "5900:5900"
+    volumes:
+      - /dev/shm:/dev/shm
+    networks:
+      - local
+      - proxy
+      - db
     labels:
       traefik.enable: "false"
 
@@ -120,3 +167,4 @@ networks:
 
 volumes:
   db:
+  pma:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,8 +72,6 @@ services:
       - WP_STATELESS_MEDIA_BUCKET=${APP_HOSTNAME:-www-planet4-test}
       - WP_STATELESS_MEDIA_ENABLED=${WP_STATELESS_MEDIA_ENABLED:-true}
       - WP_VERSION=5.4.2
-      - CODECEPTION_SELENIUM_HOST=selenium
-      - CODECEPTION_SELENIUM_PORT=4444
     env_file:
       - ./app.env
       - ./db.env
@@ -105,57 +103,12 @@ services:
       - "traefik.docker.network=planet4dockercompose_proxy"
       - "traefik.enable=true"
 
-  phpmyadmin:
-    image: phpmyadmin/phpmyadmin:4.7
-    depends_on:
-      - db
-      - traefik
-    environment:
-      PMA_USER: root
-      PMA_PASSWORD: root
-    env_file:
-      - ./db.env
-    volumes:
-      - pma:/sessions
-    networks:
-      - db
-      - proxy
-    labels:
-      traefik.backend: "pma"
-      traefik.frontend.rule: "Host:pma.www.planet4.test"
-      traefik.docker.network: "planet4dockercompose_proxy"
-      traefik.enable: "true"
-
   elasticsearch:
     image: gcr.io/planet-4-151612/elasticsearch:${ELASTICSEARCH_BUILD_TAG:-latest}
     networks:
       - local
     environment:
       - discovery.type=single-node
-    labels:
-      traefik.enable: "false"
-
-  elastichq:
-    image: elastichq/elasticsearch-hq
-    environment:
-      HQ_DEFAULT_URL: http://elasticsearch:9200
-    networks:
-      - local
-    ports:
-      - "5000:5000"
-
-  selenium:
-    image: selenium/standalone-chrome-debug:3
-    environment:
-      - VNC_NO_PASSWORD=1
-    ports:
-      - "5900:5900"
-    volumes:
-      - /dev/shm:/dev/shm
-    networks:
-      - local
-      - proxy
-      - db
     labels:
       traefik.enable: "false"
 
@@ -167,4 +120,3 @@ networks:
 
 volumes:
   db:
-  pma:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,14 +69,13 @@ It's not necessary to re-run `make dev` each time you wish to start the local de
 make run
 ```
 
-### Lightweight configuration
+### Full environment
 
-If the current setup is too heavy for your machine, there is a lighter version that skips creating some of the containers. Keep in mind though that this leaves out PhpMyAdmin, ElasticHQ and Selenium containers, so it would be harder to debug things.
-
-To use it, you need to set the relevant environmental variable. For instance:
+In order to keep the environment light, the default setup skips some containers that are useful for debugging and testing.
+Namely: PhpMyAdmin, ElasticHQ and Selenium. If you need them, you can use the full environment config by setting an environment variable:
 
 ```bash
-DOCKER_COMPOSE_FILE="docker-compose.light.yml" make run
+DOCKER_COMPOSE_FILE="docker-compose.full.yml" make run
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
We know what is the configuration we should use if we need to debug and run tests locally. It would make more sense to have a more "sane" default for contributors who won't need that in most of the cases. The commit just makes the light configuration the default one.