### PR TITLE
Make target to set up trusted certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .tmp-id
 acme.json
 artifacts
+certs
 defaultcontent/*
 !defaultcontent/.gitkeep
 persistence

--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,10 @@ hosts:
 .PHONY: build
 build: hosts run unzipimages config elastic flush
 
+.PHONY: certs
+certs:
+	./scripts/setup-certs.sh
+
 ## Run containers. Will either start or build them first if they don't exist
 .PHONY: run
 run: envcheck

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./traefik.toml:/traefik.toml
+      - ./certs:/certs
     labels:
       traefik.backend: "traefik"
       traefik.frontend.rule: "Host:traefik.${APP_HOSTNAME:-www.planet4.test}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./traefik.toml:/traefik.toml
+      - ./certs:/certs
     labels:
       traefik.backend: "traefik"
       traefik.frontend.rule: "Host:traefik.${APP_HOSTNAME:-www.planet4.test}"

--- a/scripts/setup-certs.sh
+++ b/scripts/setup-certs.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copied from https://stackoverflow.com/questions/7580508/getting-chrome-to-accept-self-signed-localhost-certificate
+
+NAME=planet4.test
+
+######################
+# Become a Certificate Authority
+######################
+
+echo 'You will get a lot of prompts. Most can use default value (leave empty), except Common Name and pass phrase.'
+echo '===== Generate CA private key '
+openssl genrsa -out certs/myCA.key 2048
+echo '===== Generate CA root certificate '
+openssl req -x509 -new -nodes \
+  -key certs/myCA.key \
+  -sha256 \
+  -days 825 \
+  -out certs/myCA.pem
+
+######################
+# Create CA-signed certs
+######################
+
+echo '===== Generate domain private key'
+openssl genrsa -out certs/$NAME.key 2048
+
+echo "===== Create a certificate-signing request for $NAME"
+openssl req -new -key certs/$NAME.key -out certs/$NAME.csr
+
+echo '===== Create a config file for the extensions'
+>certs/$NAME.ext cat <<-EOF
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = $NAME # Be sure to include the domain name here because Common Name is not so commonly honoured by itself
+DNS.2 = www.$NAME # Optionally, add additional domains (I've added a subdomain here)
+EOF
+
+echo '===== Create the signed certificate'
+openssl x509 -req \
+  -in certs/$NAME.csr \
+  -CA certs/myCA.pem \
+  -CAkey certs/myCA.key \
+  -CAcreateserial \
+  -out certs/$NAME.crt \
+  -days 825 \
+  -sha256 \
+  -extfile certs/$NAME.ext
+
+echo '===== Removing CA key, otherwise can be used to forge new certificates your browser will trust.'
+rm certs/myCA.key certs/myCA.srl
+
+echo '===== Certificates were generated. You can now import the certs/myCA.pem file into trusted CAs of your browser.'

--- a/scripts/setup-certs.sh
+++ b/scripts/setup-certs.sh
@@ -3,6 +3,8 @@
 
 NAME=planet4.test
 
+mkdir -p certs
+
 ######################
 # Become a Certificate Authority
 ######################
@@ -16,6 +18,8 @@ openssl req -x509 -new -nodes \
   -sha256 \
   -days 825 \
   -out certs/myCA.pem
+# Also create a .crt file for Mac users.
+openssl x509 -outform der -in certs/myCA.pem -out certs/myCA.crt
 
 ######################
 # Create CA-signed certs

--- a/traefik.toml
+++ b/traefik.toml
@@ -19,6 +19,9 @@ address = ":80"
 address = ":443"
 
 [entryPoints.https.tls]
+    [[entryPoints.https.tls.certificates]]
+    certFile = "/certs/planet4.test.crt"
+    keyFile = "/certs/planet4.test.key"
 
 [docker]
 endpoint = "unix:///var/run/docker.sock"


### PR DESCRIPTION
I wanted to experimented with a web worker but that really requires a certificate that is set up well, even workarounds weren't working with the default Traefik cert. I copied [a SO answer](https://stackoverflow.com/questions/7580508/getting-chrome-to-accept-self-signed-localhost-certificate) and created a script from this with a Make target. It's still interactive, not sure if we can get around that because of pass phrases. But otherwise it seems to work well and the only manual step is to import the CA .pem file that was created into your browser.