### PR TITLE
Install pcov for major php version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ test: install-codeception test-env-info test-codeception
 # php-pcov allows for zero overhead analysis. Codeception will automatically use it as coverage driver if it's present.
 .PHONY: install-pcov
 install-pcov:
-	docker-compose exec php-fpm sh -c 'apt-get update && apt-get install -yq php-pcov'
+	docker-compose exec php-fpm sh -c 'apt-get update && apt-get install -yq php$${PHP_MAJOR_VERSION}-pcov'
 	docker cp dev-templates/pcov.ini $(shell docker-compose ps -q php-fpm):/tmp/20-pcov.ini
 	docker-compose exec php-fpm sh -c 'cp /tmp/20-pcov.ini /etc/php/$${PHP_MAJOR_VERSION}/fpm/conf.d/20-pcov.ini'
 	docker-compose exec php-fpm sh -c 'mv /tmp/20-pcov.ini /etc/php/$${PHP_MAJOR_VERSION}/cli/conf.d/20-pcov.ini'


### PR DESCRIPTION
Probably due to CircleCI's next-gen images, `php-pcov` is an alias for `php8.0-pcov`, while we need `php7.3-pcov`.