### PR TITLE
Fix xdebug install following changes in package repo and xdebug version

### DIFF
--- a/dev-templates/xdebug.tmpl
+++ b/dev-templates/xdebug.tmpl
@@ -1,9 +1,7 @@
 zend_extension=xdebug.so
-xdebug.remote_host=${XDEBUG_REMOTE_HOST}
-xdebug.remote_port=9010
-xdebug.remote_enable=1
-xdebug.remote_handler=dbgp
-xdebug.profiler_enable=0;
-xdebug.profiler_enable_trigger=1;
-xdebug.profiler_output_dir="/app/source"
-xdebug.profiler_output_name="cachegrind.out.%t-%s-%R"
+xdebug.mode=${XDEBUG_MODE}
+xdebug.start_with_request=${XDEBUG_START_WITH_REQUEST}
+xdebug.client_host=${XDEBUG_REMOTE_HOST}
+xdebug.client_port=9000
+xdebug.output_dir=/app/source
+xdebug.profiler_output_name=cachegrind.out.%t-%s-%R


### PR DESCRIPTION
- Changes in the package repository have switched the default xdebug install to PHP8 (we are using PHP7.3)
- The  default xdebug version is now xdebug3

## Fixes 

- Specify PHP version for package install
- Modify default configuration according to [xdebug3 upgrade documentation](https://xdebug.org/docs/upgrade_guide) in `dev-templates/xdebug.tmpl`
- Add a target to easily change xdebug mode (maybe there's an easier way ?); run `XDEBUG_MODE=debug,profile make xdebug-mode` to activate profile mode and still use debug (see [xdebug doc](https://xdebug.org/docs/all_settings#mode) for other modes, modes are accumulative)
- Factored a check of `envsubst`
- Small fix to remove a scary `ERROR` message on first `make run` (no defaultcontent directory available, although it's declared as required for the  `db` container, cf `db.build.context` in `docker-compose.yml`)

## Test

- `make dev-install-xdebug`
- check xdebug config file content: `docker-compose exec php-fpm sh -c 'cat /etc/php/7.3/fpm/conf.d/20-xdebug.ini'`, it should look like this
```
zend_extension=xdebug.so
xdebug.mode=debug
xdebug.start_with_request=yes
xdebug.client_host=172.22.0.1
xdebug.client_port=9000
xdebug.output_dir=/app/source
xdebug.profiler_output_name=cachegrind.out.%t-%s-%R
```
- Try to change the mode `XDEBUG_MODE=debug,profile make xdebug-mode` and re-check config content. Don't stay in profile mode, it will generate a lot of `cachegrind.out.*` files in your `persistence/app` directory, run `make xdebug-mode` to go back to default.

Draft documentation for installation on VSCode is on gitbook https://app.gitbook.com/@greenpeace/s/planet4/~/diff/drafts/-MVH0PTZlgWTOPwWC-Z6/development/installation#xdebug-and-ide-configuration