### PR TITLE
Update develop branches to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ jobs:
   codeception:
     <<: *defaults
     environment:
-      APP_IMAGE: gcr.io/planet-4-151612/planet4-base-app:develop
-      OPENRESTY_IMAGE: gcr.io/planet-4-151612/planet4-base-openresty:develop
+      APP_IMAGE: gcr.io/planet-4-151612/planet4-base-app:main
+      OPENRESTY_IMAGE: gcr.io/planet-4-151612/planet4-base-openresty:main
     steps:
       - checkout
       - restore_cache:

--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ update-deps:
 .PHONY: update-base
 update-base:
 	docker-compose exec -u "${APP_USER}" php-fpm sh -c \
-		"cd /app/source && git checkout develop && git pull"
+		"cd /app/source && git checkout main && git pull"
 
 dev-install-xdebug:
 ifeq (Darwin, $(shell uname -s))

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -33,7 +33,7 @@ services:
       # - DELETE_EXISTING_FILES=false
       - GIT_REF=${GIT_REF:-main}
       - GIT_SOURCE=https://github.com/greenpeace/planet4-base
-      # - MERGE_REF=develop
+      # - MERGE_REF=main
       # - MERGE_SOURCE=https://github.com/greenpeace/planet4-flibble
       - NEWRELIC_LICENSE=${NEWRELIC_LICENSE:-false}
       # - OVERWRITE_EXISTING_FILES=false

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -43,7 +43,7 @@ services:
       traefik.enable: "false"
 
   php-fpm:
-    image: ${APP_IMAGE:-gcr.io/planet-4-151612/wordpress:develop}
+    image: ${APP_IMAGE:-gcr.io/planet-4-151612/wordpress:main}
     depends_on:
       - db
       - redis
@@ -66,7 +66,7 @@ services:
       # - DELETE_EXISTING_FILES=false
       - GIT_REF=${GIT_REF:-main}
       - GIT_SOURCE=https://github.com/greenpeace/planet4-base
-      # - MERGE_REF=develop
+      # - MERGE_REF=main
       # - MERGE_SOURCE=https://github.com/greenpeace/planet4-flibble
       - NEWRELIC_LICENSE=${NEWRELIC_LICENSE:-false}
       # - OVERWRITE_EXISTING_FILES=false
@@ -84,7 +84,7 @@ services:
       traefik.enable: "false"
 
   openresty:
-    image: ${OPENRESTY_IMAGE:-gcr.io/planet-4-151612/openresty:develop}
+    image: ${OPENRESTY_IMAGE:-gcr.io/planet-4-151612/openresty:main}
     depends_on:
       - php-fpm
       - traefik

--- a/docker-compose.stateless.yml
+++ b/docker-compose.stateless.yml
@@ -40,7 +40,7 @@ services:
       traefik.enable: "false"
 
   php-fpm:
-    image: ${APP_IMAGE:-gcr.io/planet-4-151612/planet4-base-app:develop}
+    image: ${APP_IMAGE:-gcr.io/planet-4-151612/planet4-base-app:main}
     depends_on:
       - db
       - redis
@@ -66,7 +66,7 @@ services:
       traefik.enable: "false"
 
   openresty:
-    image: ${OPENRESTY_IMAGE:-gcr.io/planet-4-151612/planet4-base-openresty:develop}
+    image: ${OPENRESTY_IMAGE:-gcr.io/planet-4-151612/planet4-base-openresty:main}
     depends_on:
       - php-fpm
       - traefik

--- a/docker-compose.tools.yml
+++ b/docker-compose.tools.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   codeception:
-    image: gcr.io/planet-4-151612/p4-codeception:develop
+    image: gcr.io/planet-4-151612/p4-codeception:main
     working_dir: /app/source
     command: /bin/false  # only needed when running specific commands
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       traefik.enable: "false"
 
   php-fpm:
-    image: ${APP_IMAGE:-gcr.io/planet-4-151612/wordpress:develop}
+    image: ${APP_IMAGE:-gcr.io/planet-4-151612/wordpress:main}
     depends_on:
       - db
       - redis
@@ -66,7 +66,7 @@ services:
       # - DELETE_EXISTING_FILES=false
       - GIT_REF=${GIT_REF:-main}
       - GIT_SOURCE=https://github.com/greenpeace/planet4-base
-      # - MERGE_REF=develop
+      # - MERGE_REF=main
       # - MERGE_SOURCE=https://github.com/greenpeace/planet4-flibble
       - NEWRELIC_LICENSE=${NEWRELIC_LICENSE:-false}
       # - OVERWRITE_EXISTING_FILES=false
@@ -82,7 +82,7 @@ services:
       traefik.enable: "false"
 
   openresty:
-    image: ${OPENRESTY_IMAGE:-gcr.io/planet-4-151612/openresty:develop}
+    image: ${OPENRESTY_IMAGE:-gcr.io/planet-4-151612/openresty:main}
     depends_on:
       - php-fpm
       - traefik


### PR DESCRIPTION
Although existing setup still works, latest images are tagged as `main` because of the branch name changes.