### PR TITLE
Add an install step for tests dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,13 @@ jobs:
           key: composer-v1-{{ .Branch }}-{{ .Revision }}-{{ .BuildNum }}
           paths:
             - defaultcontent
-      - run: make test
-      - run: make ci-extract-artifacts
+      - run:
+          name: Run acceptance tests
+          command: make test
+      - run:
+          name: Generate artifacts
+          command: make ci-extract-artifacts
+          when: always
       - store_test_results:
           path: artifacts
       - store_artifacts:

--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,7 @@ endif
 ifndef OPENRESTY_IMAGE
 	$(error OPENRESTY_IMAGE is not set)
 endif
-	@$(MAKE) lint run config ci-copyimages elastic flush install-pcov
+	@$(MAKE) lint run config ci-copyimages elastic flush test-install
 
 db/Dockerfile:
 ifndef ENVSUBST
@@ -393,7 +393,10 @@ ci-copyimages: $(LOCAL_IMAGES)
 # CODECEPTION TASKS
 
 ## Run tests with Codeception
-test: install-codeception test-env-info test-codeception
+test: test-env-info test-codeception
+
+## Install Codeception dependencies
+test-install: install-codeception install-pcov
 
 # php-pcov allows for zero overhead analysis. Codeception will automatically use it as coverage driver if it's present.
 .PHONY: install-pcov


### PR DESCRIPTION
The `test` target is missing the `install-pcov` step it doesn't work locally. On CI we run both `ci` and `test` targets, so we don't have this problem.

So I created a new target `test-install` to have all the dependencies installation there and we can adjust the docs to use that on first run.

Also fixed the Artifacts generation that didn't work on the CI.