### PR TITLE
PLANET-5977: Pre-built version of a local dev environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,58 @@ jobs:
       - run:
           name: Basic checks
           command: ./scripts/status-report.sh
+      - run:
+          name: Create release from install
+          command: |
+              mkdir -p /tmp/workspace/build
+              export DEVRELEASE_VERSION="$(date +'%Y%m%d')"
+              # <sudo> to bypass permissions issues with wflogs files
+              RELEASE=$(sudo -E make create-dev-export)
+              echo "${RELEASE}" > /tmp/workspace/build/release.txt
+              mv "${RELEASE}" /tmp/workspace/build/
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - build/*
+
+  dev-from-release:
+    machine:
+      image: ubuntu-2004:202101-01
+    environment:
+      APP_IMAGE: gcr.io/planet-4-151612/wordpress:main
+      OPENRESTY_IMAGE: gcr.io/planet-4-151612/planet4-base-openresty:main
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Create local environment from release
+          command: |
+              cp /tmp/workspace/build/* .
+              LOCAL_DEVRELEASE=$(cat /tmp/workspace/build/release.txt) make dev-from-release
+      - run:
+          name: Basic checks
+          command: ./scripts/status-report.sh
+
+  publish-release:
+    <<: *defaults
+    environment:
+      GOOGLE_PROJECT_ID: planet-4-151612
+      BUCKET_NAME: planet4-default-content
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: activate-gcloud-account.sh
+      - run:
+          name: Push dev release to cloud storage
+          command: |
+              RELEASE=$(cat /tmp/workspace/build/release.txt)
+              LATEST="planet4-persistence-latest.gz"
+              gsutil cp -a public-read /tmp/workspace/build/${RELEASE} gs://${BUCKET_NAME}
+              mv /tmp/workspace/build/${RELEASE} /tmp/workspace/build/${LATEST}
+              gsutil cp -a public-read /tmp/workspace/build/${LATEST} gs://${BUCKET_NAME}
 
 workflows:
   version: 2
@@ -70,12 +122,26 @@ workflows:
   test:
     jobs:
       - localdev
+      - dev-from-release:
+          requires:
+            - localdev
       - codeception:
           context: org-global
 
-  cron-test:
+  nightly-test-and-release:
     jobs:
       - localdev
+      - dev-from-release:
+          requires:
+            - localdev
+      - codeception:
+          context: org-global
+      - publish-release:
+          context: org-global
+          requires:
+            - localdev
+            - dev-from-release
+            - codeception
     triggers:
       - schedule:
           cron: "0 0 * * *"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,7 @@ services:
 
   node:
     image: ${NODE_IMAGE:-node:lts-alpine}
+    user: "node"
     tty: true
     networks:
       - local


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5977

> It should be possible to compile an installation on CI, and propose it as a local dev env release, allowing for a much faster time to first run, with less filesystem manipulations and compilation problems.  

## Description

This PR adds commands and workflows to enable a local Planet4 instance installation from a tar file, instead of the current full installation process of wordpress and main repos.   
It does not remove nor change any existing command.

### Build and test on CI

Since https://github.com/greenpeace/planet4-docker-compose/pull/75 we test the local environment nightly. This development adds 
- a step after this test, to create a tar file of the `persistence` folder
- a test of an installation from this tar file (same basic checks)
- a publication of this tar file as a dev release 
  (it's called release in everything I added, but maybe snapshot is a better term ? open to suggestions)

![Screenshot from 2021-03-24 13-01-45](https://user-images.githubusercontent.com/617346/112307340-20a15780-8ca1-11eb-8612-84b5e0a647fd.png)

This is a screenshot of tests during development; the `publish-release` job is now planned to happen during nightly tests, depending on the result of `localdev`, `dev-from-release` and `codeception` jobs (see `nightly-test-and-release` workflow).

The tar file is pushed on GCloud storage, in the project `planet-4-151612`, bucket `planet4-default-content`.


### Locally

New commands and variables are available to use this feature:
- `make dev-from-release` is an equivalent of `make dev` aimed at a quick start and for NRO developers
  It pulls the tar file from GCloud storage and "installs" it
- `make update-from-release` should be a static equivalent of `make update`
- `make main-repos-editable` aimed at development on `master-theme` and `plugin-gutenberg-blocks`, 
  re-clones the main repos and rebuild dependencies, composer, node_modules, etc.
- `create-dev-export` used by CI to create the tar file
- `DEVRELEASE_VERSION` specifies the version of the file to download and install
- `LOCAL_DEVRELEASE` defines which local tar file to use for installation

## Test

You want to test this, you're my favorite person by far :hugs: 

- Save your work (always save your work)
- Stop your local instance `make stop`
- Clone this repo in another directory 
  `git clone -b planet-5977 https://github.com/greenpeace/planet4-docker-compose.git p4-5977 && cd p4-5977`
- Update your docker images `make pull` (if you get an error, try creating a defaultcontent dir before `mkdir defaultcontent`)
- Check your character sheet, choose your adventure :crossed_swords::

#### As an NRO developer

Run:
```console
> make dev-from-release
```
Then do what you usually do in your development process, add your `Makefile.include` file, run  `make nro-enable` or other methods.  
The main goal is to see if unusual problems occur, especially in term of file permissions and execution.
Can you still work the same way with this build as you were before ?

#### As a P4 developer working on main repos

Run:
```console
> make dev-from-release
> make main-repos-editable
```
Then do what you usually do in your development process, editing theme and plugin, building assets, etc.  
The main goal is to see if unusual problems occur, especially in term of file permissions and execution.
Can you still work the same way with this build as you were before ?

### Expected errors

#### Permission denied
```
bash: /app/bin/composer: Permission denied
```
This should be fixed now with https://github.com/greenpeace/planet4-docker/pull/65 , if it's not, try to update docker images with `make pull`.
In the meantime run 
```console
> docker-compose exec php-fpm sh -c 'chown -f app /app/bin/composer && chown -Rf app /app/.composer'
```