### PR TITLE
Make sure selenium is up when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,6 +392,11 @@ ci-copyimages: $(LOCAL_IMAGES)
 
 # CODECEPTION TASKS
 
+selenium-run:
+	echo "Starting Selenium"
+	@docker-compose -f docker-compose.full.yml up -d selenium
+	@sleep 3
+
 ## Run tests with Codeception
 test: test-env-info test-codeception
 
@@ -428,7 +433,7 @@ test-codeception-acceptance:
 	@docker-compose exec php-fpm tests/vendor/bin/codecept run acceptance --no-redirect --xml=junit.xml --html --coverage --coverage-html coverage_acceptance
 
 .PHONY: test-codeception
-test-codeception: test-codeception-acceptance
+test-codeception: selenium-run test-codeception-acceptance
 
 .PHONY: test-codeception-failed
 test-codeception-failed:


### PR DESCRIPTION
Selenium is not built by default, it can be puzzling to have tests fail for that reason.
This ensures it runs on `make test`.

## Test

- Make sure selenium is not running
  `docker-compose -f docker-compose.full.yml stop selenium && docker-compose -f docker-compose.full.yml rm selenium`
- Run `make test` (You can stop it on the first successful test)
  - on master branch with default install, this will fail all tests
  - on this branch tests will run