### PR TITLE
PLANET-6023: nro-enable enhancements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,12 +189,6 @@ jobs:
 workflows:
   test:
     jobs:
-      # - localdev
-      # - dev-from-release:
-      #     requires:
-      #       - localdev
-      # - codeception:
-      #     context: org-global
       - localdev:
           context: org-global
       - dev-from-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,28 @@ defaults: &defaults
         <<: *docker_auth
   working_directory: /home/circleci/app
 
+commands:
+  install_gcloud:
+    steps:
+      - run:
+          name: Install gcloud
+          command: |
+              sudo apt-get remove -y --purge man-db
+              echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] \
+                https://packages.cloud.google.com/apt cloud-sdk main" \
+                | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+              curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+                sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+              sudo apt-get update && sudo apt-get install -y google-cloud-sdk
+  activate_gcloud:
+    steps:
+      - run:
+          name: Activate gcloud
+          command: |
+            git clone --depth=1 https://github.com/greenpeace/planet4-circleci.git
+            ./planet4-circleci/src/bin/activate-gcloud-account.sh
+
+
 jobs:
   codeception:
     <<: *defaults
@@ -55,6 +77,9 @@ jobs:
     environment:
       APP_IMAGE: gcr.io/planet-4-151612/wordpress:main
       OPENRESTY_IMAGE: gcr.io/planet-4-151612/planet4-base-openresty:main
+      GOOGLE_PROJECT_ID: planet-4-151612
+      NRO_NAME: finland
+      NRO_DB_VERSION: latest
     steps:
       - checkout
       - run:
@@ -72,6 +97,14 @@ jobs:
               RELEASE=$(sudo -E make create-dev-export)
               echo "${RELEASE}" > /tmp/workspace/build/release.txt
               mv "${RELEASE}" /tmp/workspace/build/
+      - install_gcloud
+      - activate_gcloud
+      - run:
+          name: Enable NRO dev environment
+          command: make nro-enable
+      - run:
+          name: Basic checks
+          command: ./scripts/status-report.sh
       - persist_to_workspace:
           root: /tmp/workspace
           paths:
@@ -90,8 +123,33 @@ jobs:
       - run:
           name: Create local environment from release
           command: |
-              cp /tmp/workspace/build/* .
+              cp /tmp/workspace/build/* ./ && \
               LOCAL_DEVRELEASE=$(cat /tmp/workspace/build/release.txt) make dev-from-release
+      - run:
+          name: Basic checks
+          command: ./scripts/status-report.sh
+
+  nro-from-release:
+    machine:
+      image: ubuntu-2004:202101-01
+    environment:
+      APP_IMAGE: gcr.io/planet-4-151612/wordpress:main
+      OPENRESTY_IMAGE: gcr.io/planet-4-151612/planet4-base-openresty:main
+      GOOGLE_PROJECT_ID: planet-4-151612
+      NRO_NAME: finland
+      NRO_DB_VERSION: latest
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - install_gcloud
+      - activate_gcloud
+      - run:
+          name: Create NRO environment from release
+          command: |
+              cp /tmp/workspace/build/* ./
+              RELEASE=$(cat /tmp/workspace/build/release.txt)
+              LOCAL_DEVRELEASE=${RELEASE} make nro-from-release
       - run:
           name: Basic checks
           command: ./scripts/status-report.sh
@@ -131,8 +189,19 @@ jobs:
 workflows:
   test:
     jobs:
-      - localdev
+      # - localdev
+      # - dev-from-release:
+      #     requires:
+      #       - localdev
+      # - codeception:
+      #     context: org-global
+      - localdev:
+          context: org-global
       - dev-from-release:
+          requires:
+            - localdev
+      - nro-from-release:
+          context: org-global
           requires:
             - localdev
       - codeception:
@@ -141,8 +210,13 @@ workflows:
 
   nightly-test-and-release:
     jobs:
-      - localdev
+      - localdev:
+          context: org-global
       - dev-from-release:
+          requires:
+            - localdev
+      - nro-from-release:
+          context: org-global
           requires:
             - localdev
       - codeception:
@@ -152,6 +226,7 @@ workflows:
           requires:
             - localdev
             - dev-from-release
+            - nro-from-release
             - codeception
     triggers:
       - schedule:

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,11 @@
 .tmp-id
 acme.json
 artifacts
-defaultcontent
+defaultcontent/*
+!defaultcontent/.gitkeep
 persistence
 secrets
 db/Dockerfile
 hosts.backup
 Makefile.include
-xdebug.out
+dev-templates/*.out

--- a/dev-templates/nginx_imgproxy.tmpl
+++ b/dev-templates/nginx_imgproxy.tmpl
@@ -1,0 +1,13 @@
+location ~ /wp-content/uploads/.*
+{
+    try_files $uri @fallback;
+}
+
+location @fallback
+{
+    resolver 8.8.8.8;
+    rewrite ^/wp-content/uploads/(.*)$ /static/${NRO_IMG_BUCKET}/$1 break;
+    #proxy_set_header Host greenpeace.org;
+    proxy_ssl_server_name on;
+    proxy_pass http://www.greenpeace.org;
+}

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -60,7 +60,7 @@ services:
       - excluded:/app/source/node_modules/
       - ./secrets/wp-stateless-media-key.json:/app/secrets/wp-stateless-media-key.json:ro
     environment:
-      - APP_ENV=${APP_ENV:-develop}
+      - APP_ENV=${APP_ENV:-local}
       - APP_HOSTNAME=${APP_HOSTNAME:-www.planet4.test}
       - APP_HOSTPATH=${APP_HOSTPATH:-}
       # - DELETE_EXISTING_FILES=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - excluded:/app/source/node_modules/
       - ./secrets/wp-stateless-media-key.json:/app/secrets/wp-stateless-media-key.json:ro
     environment:
-      - APP_ENV=${APP_ENV:-develop}
+      - APP_ENV=${APP_ENV:-local}
       - APP_HOSTNAME=${APP_HOSTNAME:-www.planet4.test}
       - APP_HOSTPATH=${APP_HOSTPATH:-}
       # - DELETE_EXISTING_FILES=false

--- a/scripts/import-db.sh
+++ b/scripts/import-db.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -u
+
+GSUTIL=$(command -v gsutil)
+DUMP_URL=
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --nro ) NRO_NAME="$2"; shift ;;
+    --project ) PROJECT_ID="$2"; shift ;;
+    --bucket ) DB_BUCKET="$2"; shift ;;
+    --version ) DB_VERSION="$2"; shift ;;
+    --dest ) DEST_DIR="$2"; shift ;;
+    --database ) DB_NAME="$2"; shift ;;
+    --dump ) DUMP_PATH="$2"; shift ;;
+    --mysql-user ) MYSQL_USER="$2"; shift ;;
+    --mysql-root-pass ) MYSQL_ROOT_PASS="$2"; shift ;;
+    --overwrite ) OVERWRITE="$2"; shift ;;
+    (--) shift; break ;;
+    (*) break ;;
+  esac
+  shift
+done
+
+NRO_NAME=${NRO_NAME:-}
+PROJECT_ID=${PROJECT_ID:-"planet-4-151612"}
+DEST_DIR=${DEST_DIR:-"./defaultcontent"}
+DB_BUCKET=${DB_BUCKET:-"planet4-${NRO_NAME}-master-db-backup"}
+DB_VERSION=${DB_VERSION:-"latest"}
+DB_NAME=${DB_NAME:-"$(echo "planet4_${NRO_NAME}" | sed 's/-/_/g')"}
+DUMP_PATH=${DUMP_PATH:-}
+OVERWRITE=${OVERWRITE:-}
+
+MYSQL_USER=${MYSQL_USER:-"planet4"}
+MYSQL_ROOT_PASS=${MYSQL_ROOT_PASS:-"root"}
+
+# MySQL shorthand functions
+function mysql_root_exec() {
+  docker-compose exec db mysql -uroot -p"${MYSQL_ROOT_PASS}" "$@"
+}
+
+function mysql_root_exec_notty() {
+  docker-compose exec -T db mysql -uroot -p"${MYSQL_ROOT_PASS}" "$@"
+}
+
+# Create database and check for content
+# Display a validation prompt if content would be overwritten
+function check_existing_db() {
+  mysql_root_exec -e \
+    "create database if not exists ${DB_NAME}; \
+    grant all privileges on ${DB_NAME}.* to '${MYSQL_USER}'@'%'; \
+    use ${DB_NAME}; \
+    reset master;"
+
+  TABLE=$(mysql_root_exec -D "${DB_NAME}" -e "show tables like 'wp_posts'\G" | tail -1)
+  if [[ "${TABLE}" == *"wp_posts"* ]] && [[ "${OVERWRITE}" != "true" ]]; then
+    if [[ "${OVERWRITE}" == "false" ]]; then
+      printf "Skipping DB import.\n"
+      exit 0;
+    fi
+    read -p "Database ${DB_NAME} exists, overwrite ? [y/N]: " -n 1 -r owdb
+    printf "\n"
+    if [[ "${owdb}" != "y" ]] && [[ "${owdb}" != "Y" ]]; then
+      printf "Skipping DB import.\n"
+      exit 0;
+    fi
+  fi
+}
+
+# Switch GCloud project
+function switch_project() {
+  echo "Setting gcloud project to ${PROJECT_ID} ..."
+  gcloud config set project "${PROJECT_ID}"
+}
+
+# Look for a dump corresponding to given parameters:
+# bucket, NRO, version, existing dump
+function find_db() {
+  if [[ -n "${DUMP_URL}" ]]; then
+    echo "Dump given: ${DUMP_URL}"
+    return 0
+  fi
+
+  if [[ -n "${DUMP_PATH}" ]]; then
+    DUMP_NAME=$(basename "${DUMP_PATH}")
+  else
+    DUMP_NAME=
+  fi
+
+  # Sort results by date and extract last filename only
+  if [[ -n "${DUMP_NAME}" ]]; then
+    DUMP_URL=$(gsutil ls -r "gs://${DB_BUCKET}/**/${DUMP_NAME}")
+  elif [[ "${DB_VERSION}" == "latest" ]]; then
+    DUMP_URL=$(gsutil ls -rl "gs://${DB_BUCKET}/**" | sort -k2n | \
+               tail -n1 | awk 'END {$1=$2=""; sub(/^[ \t]+/, ""); print }')
+  else
+    DUMP_PREFIX="planet4-${NRO_NAME}-master-v${DB_VERSION}"
+    DUMP_URL=$(gsutil ls -r "gs://${DB_BUCKET}/v${DB_VERSION}/${DUMP_PREFIX}-*.sql.gz")
+  fi
+
+  echo "Dump found: ${DUMP_URL}"
+}
+
+# Download dump file
+# If no URL but file already exists, return ok
+# Display validation prompt if file already exists
+function download_db() {
+  if [[ -z "${DUMP_URL}" ]]; then
+    if [[ -f "${DUMP_PATH}" ]]; then
+      return 0
+    fi
+
+    echo "No dump found."
+    exit 1
+  fi
+
+  DUMP_NAME=$(basename "${DUMP_URL}")
+  DUMP_PATH="${DEST_DIR}/${DUMP_NAME}"
+
+  if [[ -f "${DUMP_PATH}" ]] && [[ "${OVERWRITE}" != "true" ]]; then
+    if [[ "${OVERWRITE}" == "false" ]]; then
+      printf "Skipping database download.\n" && return 0;
+    fi
+    read -p "File ${DUMP_PATH} exists, overwrite ? [y/N]: " -n 1 -r owdump
+    printf "\n"
+    if [[ "${owdump}" != "y" ]] && [[ "${owdump}" != "Y" ]]; then
+      printf "Skipping database download.\n" && return 0;
+    fi
+  fi
+
+  echo "Downloading database from ${DUMP_URL} ..."
+  gsutil cp "${DUMP_URL}" "${DEST_DIR}"
+}
+
+# Import dump to database
+function import_db() {
+  if [[ ! -f "${DUMP_PATH}" ]]; then
+    echo "Dump file <${DUMP_PATH}> does not exist or is not specified."
+    exit 1
+  fi
+
+  echo "Importing database content from ${DUMP_PATH} ..."
+  zcat < "${DUMP_PATH}" | mysql_root_exec_notty "${DB_NAME}"
+  # Fix GTID_PURGED value issue
+  mysql_root_exec -D "${DB_NAME}" -e 'RESET MASTER'
+}
+
+#
+# Main
+# Import will work without gsutil, if --dump is a valid dump file
+#
+
+check_existing_db
+if [[ ${GSUTIL} ]]; then
+  switch_project
+  find_db
+  download_db
+fi
+import_db

--- a/scripts/import-db.sh
+++ b/scripts/import-db.sh
@@ -67,6 +67,15 @@ function check_existing_db() {
   fi
 }
 
+# Check gcloud auth
+function check_auth() {
+  echo "Checking gcloud authentication ..."
+  if [[ $(gcloud auth list --filter=status:ACTIVE --format="value(account)" | wc -l) -lt 1 ]]; then
+    echo "No gcloud account is currently active, " \
+      "please use <gcloud auth login> to enable automatic database import."
+  fi
+}
+
 # Switch GCloud project
 function switch_project() {
   echo "Setting gcloud project to ${PROJECT_ID} ..."
@@ -152,6 +161,7 @@ function import_db() {
 
 check_existing_db
 if [[ ${GSUTIL} ]]; then
+  check_auth
   switch_project
   find_db
   download_db

--- a/scripts/status-report.sh
+++ b/scripts/status-report.sh
@@ -81,7 +81,7 @@ function check_homepage() {
   # Check homepage content
   hp_status_code=$(echo "${homepage_content}" | grep "< HTTP/1.1")
   hp_title=$(echo "${homepage_content}" | grep -Pzo "(?s)<title>.*</title>" | tr -d '\n\0')
-  hp_php_errors=$(echo "${homepage_content}" | grep -Pzo "(Warning|Error|Notice|Deprecated)(.*)\n")
+  hp_php_errors=$(echo "${homepage_content}" | grep -Pzo "<b>(Warning|Error|Notice|Deprecated)</b>(.*)\n")
   if [[ "${hp_status_code}" == "" ]]; then
     errors_found=1
     echo "Status code: $(nok)"
@@ -116,7 +116,7 @@ function check_login() {
   # Check login content
   lg_status_code=$(echo "${login_content}" | grep "< HTTP/1.1")
   lg_form=$(echo "${login_content}" | grep "<form name=\"loginform\"")
-  lg_php_errors=$(echo "${login_content}" | grep -Pzo "(Warning|Error|Notice|Deprecated)(.*)\n" | tr -d '\0')
+  lg_php_errors=$(echo "${login_content}" | grep -Pzo "<b>(Warning|Error|Notice|Deprecated)</b>(.*)\n" | tr -d '\0')
   if [[ "${lg_status_code}" == "" ]]; then
     errors_found=1
     echo "Status code: $(nok)"
@@ -165,6 +165,8 @@ function filter_logs() {
     # Warnings during install
     "NOTICE: PHP message: PHP Warning:  Redis::connect(): php_network_getaddresses: getaddrinfo failed"
     "NOTICE: PHP message: PHP Warning:  filectime(): stat failed"
+    # Warning during NRO install
+    "ssmtp: Cannot open smtp:25"
     # Xdebug running without client
     "NOTICE: PHP message: Xdebug: [Step Debug] Could not connect to debugging client."
     # APM installation


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6023

> 'make nro-enable' should result in a local website equivalent to a snapshot of the live one.

This PR adds functionalities to the `nro-enable` command so that the resulting instance has most of the features of the production website, including database and images.

---

## Features and modifications

### Faster installation

Although your NRO installation workflow can still be `make dev && make nro-enable`, this PR adds a command using the quick install developed in #77.
`make nro-from-release` will install a pre-built planet4 instance from a recent codebase, and run `nro-enable` on it, which can now import database, run missing composer recipes, and activate an image proxy.

### Variables

- `NRO_NAME`: `NRO_*` variables are still usable, but most of them can be replaced by `NRO_NAME`, the rest will be deduced from this one.
- `NRO_DB_VERSION` is used to pull a database dump version from your google storage backups
- `NRO_DB_DUMP` is used to use a local file that you previously downloaded

Previous variables are still overwritable and will default to:
```makefile
NRO_REPO ?= https://github.com/greenpeace/planet4-$(NRO_NAME).git
NRO_BRANCH ?= main
NRO_THEME ?= planet4-child-theme-$(NRO_NAME)
```

You can visualize how variables will be generated with  `make nro-list-variables` (it takes your `Makefile.include` into account).
```console
> NRO_NAME=finland make nro-list-variables
NRO variables:
* NRO_APP_HOSTNAME = www.planet4.test
* NRO_APP_HOSTPATH =
* NRO_BRANCH = main
* NRO_DATABASE = planet4_finland
* NRO_DB_DUMP =
* NRO_DB_IMPORT = true
* NRO_DB_BUCKET = planet4-finland-master-db-backup
* NRO_DB_PROJECT = planet-4-151612
* NRO_DB_VERSION = latest
* NRO_DIRNAME = planet4-finland
* NRO_IMG_BUCKET = planet4-finland-stateless
* NRO_NAME = finland
* NRO_REPO = https://github.com/greenpeace/planet4-finland.git
* NRO_THEME = planet4-child-theme-finland
```

### Database download and import

A database backup can be automatically downloaded and imported, if variable `NRO_DB_VERSION` is provided. It can take a version number `NRO_DB_VERSION ?= 1.6`, or a keyword **latest** `NRO_DB_VERSION ?= latest` that will try to get the latest file.
It uses `gsutil`, so you need to install gcloud locally, see https://cloud.google.com/storage/docs/gsutil_install , and authenticate with `gcloud auth login`.  
Alternatively, you can download a dump manually and specify it with `NRO_DB_DUMP ?= my-db.sql.gz`. If the file does not exist, the command will try to download it from gcloud.  
NRO databases are imported in a different database than the default one, the name of the database is `planet4_$(NRO_NAME)`. This means you can have multiple databases living in the db container.  If a database with this name already exists and has wordpress tables, the script will prompt for your approval before overwriting it.

It is possible to specify a different gcloud project `NRO_DB_PROJECT` and bucket `NRO_DB_BUCKET` if the default configuration doesn't fit your need.

### Image proxy

An nginx configuration is added as a fallback to http queries to `/wp-content/uploads` folder. It will redirect those failed queries to your production stateless bucket. 
- This proxy can be disabled with `make nro-disable-image-proxy`.
- You can point to a different bucket with the variable `NRO_IMG_BUCKET`. URL will be `http://www.greenpeace.org/static/${NRO_IMG_BUCKET}/`. If this variable is set empty, the proxy will not be activated.

### Test pipeline

This is the PR test pipeline for, well, test purposes, but will move to the nightly cron job before merge. Regular test will mostly be the same, without `publish-release` step.
![Screenshot from 2021-03-30 19-51-33](https://user-images.githubusercontent.com/617346/113033533-6a061100-9191-11eb-89f0-9a4d1d459316.png)
- **codeception** is the usual test suite
- **localdev** runs
  - `make dev` to create a dev instance - basic checks are run against it
  - `make create-dev-export` to export a release from a clean tested dev instance
  - `make nro-enable` to test the installation of an NRO instance - basic checks are run against it
- **dev-from-release** runs an installation from the release previously exported, to test its viability
- **nro-from-release** runs a dev+nro installation from the release previously exported, to test its viability
- **publish-release** pushes the dev release to cloud storage, saving it as `planet4-persistence-YYYYmmdd` and `planet4-persistence-latest`

### Output cleaning

Makefile output has been cleaned/silenced a bit to be more concise and display less confusing messages.

### Permanent defaultcontent folder

`./defaultcontent/` is necessary for any interaction with docker-compose (because of `db` container depending on it) and on every run. It is easier to have it in the repository and keep it than track all the commands and interactions depending on it or throwing error messages because of it.

## <a id="test" />Test
<details>
<summary><b>MacOS prerequisites</b> (click for details)

MacOS comes with different (outdated) versions of some GNU tools, this makes cross-platform scripts difficult to develop and limits some possibilities. You should install recent `make` & `bash` versions so that we all work with the same basic tools.
</summary>

- Install updated `bash`, `make` and `grep` commands
  `brew install bash make grep`
- Replace default commands by the updated ones:
  - Allow and use bash:
    - Edit `/etc/shells` and add `/usr/local/bin/bash`
    - Run `chsh -s /usr/local/bin/bash`
  - Add `make` and `grep` to your `$PATH` and reload config:
    - Edit `~/.bashrc` (or your custom shell equivalent) and add
      `PATH="$(brew --prefix)/opt/make/libexec/gnubin:$PATH"`
      `PATH="$(brew --prefix)/opt/grep/libexec/gnubin:$PATH"`
    - Reload with `source ~/.bashrc`
 
If you prefer not to replace default commands, you can add custom configuration to your `Makefile.include` as shown below, and you should then use `gmake` everytime `make` is mentioned.
```
CUSTOM_SHELL := /usr/local/bin/bash
CUSTOM_MAKE := gmake
```
</details>

#### Test steps

- `make stop` your current instance, save your work
- (Not required but recommended) Install gcloud & gsutil https://cloud.google.com/storage/docs/gsutil_install , and authenticate `gcloud auth login`
- Clone in a new folder
  `git clone -b planet-6023 https://github.com/greenpeace/planet4-docker-compose.git p4-6023 && cd p4-6023`
  - Make sure you have the latest docker images with `make pull`
- Configure
  - `echo "NRO_NAME ?= finland" > Makefile.include`
  - if `gsutil` is installed and configured: `echo "NRO_DB_VERSION ?= latest" >> Makefile.include`
  - if `gsutil` is not installed and you want to use a local tar file: `echo "NRO_DB_DUMP ?= db.file.gz" >> Makefile.include`
  - if none of those DB variables are specified, no database will be imported
- Run
  `make nro-from-release`
- Optionally, once you have a running install, try switching between NROs
  `NRO_NAME=japan make nro-enable`

#### Expected errors

- *Warning: Redis::connect(): php_network_getadresses: ...*
  A temporary warning happening while the instance is not configured properly, it should disappear by the end of the installation process.
- *Script wp theme activate ... returned with error code 1*
  An error happening when the command doesn't find the theme to activate, you might have to specify `NRO_THEME`, although installation should still work.
  If your theme is not activated, go in `make php-shell`, look for your theme with `wp theme list`, and activate it with `wp theme activate <theme>`