### PR TITLE
PLANET-6045 Add step to rsync tests to initial folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,6 +425,8 @@ test-codeception-unit:
 # The confusingly named `--no-redirect` option is because of https://github.com/Codeception/Codeception/pull/5498 .
 .PHONY: test-codeception-acceptance
 test-codeception-acceptance:
+	@docker-compose exec php-fpm rsync -a --delete public/wp-content/themes/planet4-master-theme/tests/acceptance/ public/wp-content/plugins/planet4-plugin-gutenberg-blocks/tests/acceptance/ tests/acceptance/
+	@docker-compose exec php-fpm rsync -a --delete public/wp-content/themes/planet4-master-theme/tests/data/ tests/_data/
 	@docker-compose exec php-fpm tests/vendor/bin/codecept run acceptance --no-redirect --xml=junit.xml --html --coverage --coverage-html coverage_acceptance
 
 .PHONY: test-codeception


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6045

---

Rsync tests back to the directory codeception expects to find them.

**Relevant PRs:**
- https://github.com/greenpeace/planet4-master-theme/pull/1355
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/547
- https://github.com/greenpeace/planet4-base/pull/131

**Testing**
1. On your local dev environment, checkout master-theme and plugin-blocks to `planet-6045`.
2. You should do the same for the base repository. The proper way is to go inside the base repo (`persistence/app`) and checkout to `planet-6045` branch. You can also just delete all acceptance tests inside `tests/acceptance/` folder.
3. Run the environment (`make run`)
4. Make sure Selenium is running (`docker-compose -f docker-compose.full.yml up -d selenium`)
5. And run the tests (`make test`). If it's the first time you may need to run `make test-install`.

Result: Codeception should be able to find the tests.