### PR TITLE
Fix docker layer caching issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
             - composer-v1-{{ .Branch }}
             - composer-v1
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - run: make ci
       - save_cache:
           key: composer-v1-{{ .Branch }}-{{ .Revision }}-{{ .BuildNum }}

--- a/scripts/status-report.sh
+++ b/scripts/status-report.sh
@@ -167,6 +167,8 @@ function filter_logs() {
     "NOTICE: PHP message: PHP Warning:  filectime(): stat failed"
     # Xdebug running without client
     "NOTICE: PHP message: Xdebug: [Step Debug] Could not connect to debugging client."
+    # APM installation
+    "Sending events to APM Server failed."
     # FPM regular messages
     "NOTICE: using inherited socket fd"
     "NOTICE: fpm is running, pid"


### PR DESCRIPTION
`codeception` job sometimes fails because it uses outdated versions of theme and plugin repositories.

## Fix 

We can reliably trigger and fix this problem by toggling the option `docker_layer_caching` in circleci config. Setting it to `false` fixes the issue.  
Also includes a fix for status report failing with recent APM installation.

## Comments
My guess would be that circleci defines its docker layers cache based on Dockerfiles only, but also caches content generated on container startup, and our images execute a lot of installations in startup scripts, using [my_init feature of phusion/baseimage](https://github.com/phusion/baseimage-docker#running-scripts-during-container-startup). Not sure how to test this theory (or how long it would take), but this solution seems to reliably fix this problem anyway.

Quoting CircleCI doc https://circleci.com/docs/2.0/docker-layer-caching/
> DLC caches the individual layers of any Docker images built during your CircleCI jobs, 
> and then reuses unchanged image layers on subsequent CircleCI runs, rather than rebuilding the entire image every time.
> In short, **the less your Dockerfiles change** from commit to commit, the faster your image-building steps will run.

![Screenshot from 2021-04-13 10-38-03](https://user-images.githubusercontent.com/617346/114523183-5ef8b980-9c44-11eb-9b9b-75c657adf6ea.png)
_Alternating docker layer caching true/false, fun fun fun_
