### PR TITLE
PLANET-5963: Disable APM by default on local environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - APP_HOSTNAME=${APP_HOSTNAME:-www.planet4.test}
       - APP_HOSTPATH=${APP_HOSTPATH:-}
       # - DELETE_EXISTING_FILES=false
+      - ELASTIC_APM_ENABLED=${ELASTIC_APM_ENABLED:-false}
       - GIT_REF=${GIT_REF:-main}
       - GIT_SOURCE=https://github.com/greenpeace/planet4-base
       # - MERGE_REF=develop


### PR DESCRIPTION
APM needs to connect to a server and generates error logs when it fails doing it.  
Disabling it by default on local environment, where it doesn't have a server running, greatly limits these errors in logs.

## Test 

Build a new instance with `make dev`, you shouldn't see any error related to APM displayed in your shell.

_Example of install output before this fix_
![Screenshot from 2021-04-13 15-50-47](https://user-images.githubusercontent.com/617346/114563846-1525c880-9c70-11eb-860f-094d4df09b34.png)


