### PR TITLE
PLANET-6061: Alert user on existing content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ down:
 
 ## Create containers, install developer tools, build assets
 .PHONY: dev
-dev: hosts repos run unzipimages config deps elastic flush status
+dev: check-content-before-install hosts repos run unzipimages config deps elastic flush status
 	@if command -v xattr &> /dev/null; then \
 		$(MAKE) fix-ownership; \
 	fi
@@ -341,6 +341,44 @@ check-envsubst:
 ifndef ENVSUBST
 	$(error Command: 'envsubst' not found, please install using your package manager)
 endif
+
+.ONESHELL:
+check-content-before-install: envcheck
+	@export $$(sed -e '/^\#/d' .env | xargs)
+	@export $$(sed -e '/^\#/d' app.env | xargs)
+	content_exists=false
+	echo "Checking content for project $${COMPOSE_PROJECT_NAME} ..."
+	if [[ ! -z "$$(ls -A persistence)" ]]; then
+		content_exists=true
+		echo "- Some content is already in the ./persistence folder."
+	fi
+	if [[ $$(docker container ls -a --format '{{.Names}}' | grep "^$${COMPOSE_PROJECT_NAME}_" | wc -l) -gt 0 ]]; then
+		content_exists=true
+		echo "- Some containers already exist for this project:"
+		docker container ls -a --filter name="$${COMPOSE_PROJECT_NAME}_" \
+												--format 'table {{.ID}}\t{{.Names}}\t{{.Status}}\t{{.CreatedAt}}'
+	fi
+	if [[ $$(docker volume ls --format '{{.Name}}' | grep "^$${COMPOSE_PROJECT_NAME}_" | wc -l) -gt 0 ]]; then
+		content_exists=true
+		echo "- Some volumes already exist for this project:"
+		docker volume ls --filter name="$${COMPOSE_PROJECT_NAME}_"
+	fi
+	if [[ $$(docker network ls --format '{{.Name}}' | grep "^$${COMPOSE_PROJECT_NAME}_" | wc -l) -gt 0 ]]; then
+		content_exists=true
+		echo "- Some networks already exist for this project:"
+		docker network ls --filter name="$${COMPOSE_PROJECT_NAME}_"
+	fi
+	if [[ "$${APP_ENV}" == "develop" ]] && [[ "$${content_exists}" == true ]]; then
+		printf "\n"
+		echo "You should run <make clean> before continuing, as this situation could lead to unexpected results."
+		read -p "Do you still want to continue ? [y/N]: " -n 1 -r continue
+		printf "\n"
+		if [[ "$${continue}" != "y" ]] && [[ "$${continue}" != "Y" ]]; then
+		  printf "Aborting. \n"
+			exit 1
+		fi
+	fi
+	printf "OK.\n"
 
 # MacOS handles mixed ownership of files poorly and can freeze on some operations
 # This command restores proper ownership


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6061

> Running `make dev` when some docker containers (on the same prefix) or wordpress content already exist can lead to unpredictable results. We should add a control before `make dev`.

`make check-content-before-install` will look for containers, volumes and networks corresponding to the current docker-compose project (using `COMPOSE_PROJECT_NAME` prefix), and prompt the user to use `make clean` if any of those exist.
It runs before `make dev` to prevent any unexpected state.

![Screenshot from 2021-04-13 16-31-21](https://user-images.githubusercontent.com/617346/114569947-b5322080-9c75-11eb-979d-bf8c7442dbb8.png)

## Test

- On a running instance, try to run `make dev`
  - You should get a prompt advising you to run `make clean` and asking you if you want to continue
- On a clean empty instance (a different project name, or an instance after `make clean`), no prompt should appear