### PR TITLE
PLANET-6019: Deactivate Elasticpress on local environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,13 +514,16 @@ start-stateless:
 # POST INSTALL AND CONFIGURATION TASKS
 
 .PHONY: config
-config:
+config: check-services
 	docker-compose exec -T php-fpm wp option set rt_wp_nginx_helper_options '$(NGINX_HELPER_JSON)' --format=json
 	docker-compose exec -T php-fpm wp rewrite structure $(REWRITE)
 	docker-compose exec php-fpm wp option patch insert planet4_options cookies_field "Planet4 Cookie Text"
 	docker-compose exec php-fpm wp user update $(WP_ADMIN_USER) --user_pass=$(WP_ADMIN_PASS) --role=administrator
-	docker-compose exec php-fpm wp plugin deactivate wp-stateless
 	docker-compose exec php-fpm wp option update ep_host $(ELASTICSEARCH_HOST)
+	docker-compose exec php-fpm wp plugin deactivate wp-stateless
+	if [[ -z "${ELASTIC_ENABLED}" ]]; then \
+		docker-compose exec php-fpm wp plugin deactivate elasticpress;\
+	fi
 	$(MAKE) flush
 
 .PHONY: config-stateless


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6019
Related to: https://github.com/greenpeace/planet4-master-theme/pull/1361

On local environment, Elasticsearch container is disabled by default.
Elasticpress plugin should be deactivated so that it doesn't throw Exceptions when it can't connect to a server.

## Test

- Check that your Elasticpress plugin is enabled, and Elasticsearch container does not run
  `docker-compose exec php-fpm wp plugin status elasticpress`
  `docker-compose ps -a elasticsearch`
- Run `make config` and re-check the plugin status
  - It should now be disabled
- A basic `make dev` should now deactivate the elasticpress plugin during configuration
