### PR TITLE
PLANET-6019: Empty ElasticPress host when ES is not running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -613,10 +613,11 @@ config: check-services
 	docker-compose exec -T php-fpm wp rewrite structure $(REWRITE)
 	docker-compose exec php-fpm wp option patch insert planet4_options cookies_field "Planet4 Cookie Text"
 	docker-compose exec php-fpm wp user update $(WP_ADMIN_USER) --user_pass=$(WP_ADMIN_PASS) --role=administrator
-	docker-compose exec php-fpm wp option update ep_host $(ELASTICSEARCH_HOST)
 	docker-compose exec php-fpm wp plugin deactivate wp-stateless
 	if [[ -z "${ELASTIC_ENABLED}" ]]; then \
-		docker-compose exec php-fpm wp plugin deactivate elasticpress;\
+		docker-compose exec php-fpm wp option update ep_host ''
+	else \
+		docker-compose exec php-fpm wp option update ep_host $(ELASTICSEARCH_HOST)
 	fi
 	$(MAKE) flush
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6019
Related to: https://github.com/greenpeace/planet4-docker-compose/pull/85

Setting ElasticPress host to an empty string stops it from trying to connect to a server and throwing exceptions, and changes its error message in the admin panel to an information one. It solves the main issues of planet-6019 without touching the Search class.

Fixes [local dev env build](https://app.circleci.com/pipelines/github/greenpeace/planet4-docker-compose/529/workflows/560d9383-79cf-481f-8102-e1aba3a10c02/jobs/908) and doesn't ~embarassingly break search indexing everywhere~ impact production (If it does I will eat my old keyboard).

## Test

- Check current EP configuration
  `docker-compose exec php-fpm wp option get ep_host`
- Using the default docker-compose config file `docker-compose.yml`, run `make config`
  - This should modify the host config
  - Check that `docker-compose exec php-fpm wp option get ep_host` gives an empty result
- Using the full docker-compose config file, run `COMPOSE_FILE=docker-compose.full.yml make config`
  - Check that the configuration is the local ES server `http://elasticsearch:9200/`