### PR TITLE
PLANET-6114 Add lint CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 ---
+version: 2.1
+
 docker_auth: &docker_auth
   username: $DOCKERHUB_USERNAME
   password: $DOCKERHUB_PASSWORD
@@ -9,8 +11,6 @@ defaults: &defaults
       auth:
         <<: *docker_auth
   working_directory: /home/circleci/app
-
-version: 2
 
 jobs:
   codeception:
@@ -116,9 +116,19 @@ jobs:
               mv /tmp/workspace/build/${RELEASE} /tmp/workspace/build/${LATEST}
               gsutil cp -a public-read /tmp/workspace/build/${LATEST} gs://${BUCKET_NAME}
 
-workflows:
-  version: 2
+  lint:
+    <<: *defaults
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - checkout
+      - run:
+          name: Lint
+          command: |
+            make lint
+            make lint-commit
 
+workflows:
   test:
     jobs:
       - localdev
@@ -127,6 +137,7 @@ workflows:
             - localdev
       - codeception:
           context: org-global
+      - lint
 
   nightly-test-and-release:
     jobs:

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make lint-commit || exit 1

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ all: build config status
 	@echo "Ready"
 
 .PHONY: init
-init: .git/hooks/pre-commit
+init: .git/hooks/pre-commit .git/hooks/post-commit
 
 .git/hooks/%:
 	@chmod 755 .githooks/*
@@ -118,7 +118,7 @@ init: .git/hooks/pre-commit
 
 .PHONY : lint
 lint: init
-	@$(MAKE) -j lint-docker lint-sh lint-yaml lint-ci
+	@$(MAKE) -j lint-docker lint-sh lint-yaml
 
 lint-docker: db/Dockerfile
 ifndef DOCKER
@@ -138,11 +138,8 @@ ifndef YAMLLINT
 endif
 	@find . ! -path './persistence/*' -type f -name '*.yml' | xargs yamllint
 
-lint-ci:
-ifndef CIRCLECI
-	$(error "circleci is not installed: https://circleci.com/docs/2.0/local-cli/#installation")
-endif
-	@circleci config validate >/dev/null
+lint-commit:
+	@npx commitlint -V --from master
 
 # ============================================================================
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,12 @@
+// https://github.com/conventional-changelog/commitlint/blob/master/docs/reference-rules.md
+module.exports = {
+  'rules': {
+    'header-max-length': [2, 'always', 100],
+    'header-min-length': [2, 'always', 10],
+    'header-case': [2, 'always', 'sentence-case'],
+    'header-full-stop': [2, 'never', '.'],
+    'body-leading-blank': [2, 'always'],
+    'body-empty': [2, 'never'],
+    'body-case': [2, 'always', 'sentence-case']
+  }
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6114

---

1. Added some very basic rules based on what we [already do](https://support.greenpeace.org/planet4/development/git-guidelines). [Documentation](https://github.com/conventional-changelog/commitlint/blob/master/docs/reference-rules.md)

2. Also bumped CI config version and removed lint-ci because circleci cli tool doesn't support 2.1

3. Add a post-commit hook to lint commits