### PR TITLE
PLANET-6169 Sent a Slack notification on nightly build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ defaults: &defaults
         <<: *docker_auth
   working_directory: /home/circleci/app
 
+orbs:
+  slack: circleci/slack@3.4.2
+
 commands:
   install_gcloud:
     steps:
@@ -40,6 +43,10 @@ jobs:
     environment:
       APP_IMAGE: gcr.io/planet-4-151612/planet4-base-app:main
       OPENRESTY_IMAGE: gcr.io/planet-4-151612/planet4-base-openresty:main
+    parameters:
+      notify:
+        type: boolean
+        default: false
     steps:
       - checkout
       - restore_cache:
@@ -66,10 +73,14 @@ jobs:
           path: artifacts
       - store_artifacts:
           path: artifacts
-      - run:
-          name: Notify failure
-          when: on_fail
-          command: TYPE="Codeception" notify-job-failure.sh
+      - when:
+          condition: << parameters.notify >>
+          steps:
+            # Notify p4-builds-ci
+            - slack/status:
+                fail_only: true
+                channel: C024ZM2UB55
+                webhook: ${SLACK_NRO_WEBHOOK}
 
   localdev:
     machine:
@@ -80,6 +91,10 @@ jobs:
       GOOGLE_PROJECT_ID: planet-4-151612
       NRO_NAME: finland
       NRO_DB_VERSION: latest
+    parameters:
+      notify:
+        type: boolean
+        default: false
     steps:
       - checkout
       - run:
@@ -109,6 +124,14 @@ jobs:
           root: /tmp/workspace
           paths:
             - build/*
+      - when:
+          condition: << parameters.notify >>
+          steps:
+            # Notify p4-builds-ci
+            - slack/status:
+                fail_only: true
+                channel: C024ZM2UB55
+                webhook: ${SLACK_NRO_WEBHOOK}
 
   dev-from-release:
     machine:
@@ -116,6 +139,10 @@ jobs:
     environment:
       APP_IMAGE: gcr.io/planet-4-151612/wordpress:main
       OPENRESTY_IMAGE: gcr.io/planet-4-151612/planet4-base-openresty:main
+    parameters:
+      notify:
+        type: boolean
+        default: false
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -128,6 +155,14 @@ jobs:
       - run:
           name: Basic checks
           command: ./scripts/status-report.sh
+      - when:
+          condition: << parameters.notify >>
+          steps:
+            # Notify p4-builds-ci
+            - slack/status:
+                fail_only: true
+                channel: C024ZM2UB55
+                webhook: ${SLACK_NRO_WEBHOOK}
 
   nro-from-release:
     machine:
@@ -138,6 +173,10 @@ jobs:
       GOOGLE_PROJECT_ID: planet-4-151612
       NRO_NAME: finland
       NRO_DB_VERSION: latest
+    parameters:
+      notify:
+        type: boolean
+        default: false
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -153,12 +192,24 @@ jobs:
       - run:
           name: Basic checks
           command: ./scripts/status-report.sh
+      - when:
+          condition: << parameters.notify >>
+          steps:
+            # Notify p4-builds-ci
+            - slack/status:
+                fail_only: true
+                channel: C024ZM2UB55
+                webhook: ${SLACK_NRO_WEBHOOK}
 
   publish-release:
     <<: *defaults
     environment:
       GOOGLE_PROJECT_ID: planet-4-151612
       BUCKET_NAME: planet4-default-content
+    parameters:
+      notify:
+        type: boolean
+        default: false
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -173,6 +224,14 @@ jobs:
               gsutil cp -a public-read /tmp/workspace/build/${RELEASE} gs://${BUCKET_NAME}
               mv /tmp/workspace/build/${RELEASE} /tmp/workspace/build/${LATEST}
               gsutil cp -a public-read /tmp/workspace/build/${LATEST} gs://${BUCKET_NAME}
+      - when:
+          condition: << parameters.notify >>
+          steps:
+            # Notify p4-builds-ci
+            - slack/status:
+                fail_only: true
+                channel: C024ZM2UB55
+                webhook: ${SLACK_NRO_WEBHOOK}
 
   lint:
     <<: *defaults
@@ -206,17 +265,22 @@ workflows:
     jobs:
       - localdev:
           context: org-global
+          notify: true
       - dev-from-release:
+          notify: true
           requires:
             - localdev
       - nro-from-release:
           context: org-global
+          notify: true
           requires:
             - localdev
       - codeception:
           context: org-global
+          notify: true
       - publish-release:
           context: org-global
+          notify: true
           requires:
             - localdev
             - dev-from-release


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6169

---

Using existing Slack webhook configuration except in a different channel (`#p4-builds-ci`). We can use this channel to post similar type of alerts (eg. docker repo weekly builds, dev sites weekend build, etc).

This adds the notification on all jobs that are part of the nightly build, but only when two conditions are met:
1. The job fails
2. The job is part of the nightly workflow (using a parameter for that)

To test that, I added the step to the `localdev` job without any condition restrictions and [this is how it looks](https://greenpeace-gpi.slack.com/archives/C024ZM2UB55/p1623998047000100).