### PR TITLE
PLANET-5963: Skip APM agent installation on local env

### DIFF
--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -66,6 +66,7 @@ services:
       # - DELETE_EXISTING_FILES=false
       - GIT_REF=${GIT_REF:-main}
       - GIT_SOURCE=https://github.com/greenpeace/planet4-base
+      - INSTALL_APM_AGENT=${INSTALL_APM_AGENT:-false}
       # - MERGE_REF=develop
       # - MERGE_SOURCE=https://github.com/greenpeace/planet4-flibble
       - NEWRELIC_LICENSE=${NEWRELIC_LICENSE:-false}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,9 +64,9 @@ services:
       - APP_HOSTNAME=${APP_HOSTNAME:-www.planet4.test}
       - APP_HOSTPATH=${APP_HOSTPATH:-}
       # - DELETE_EXISTING_FILES=false
-      - ELASTIC_APM_ENABLED=${ELASTIC_APM_ENABLED:-false}
       - GIT_REF=${GIT_REF:-main}
       - GIT_SOURCE=https://github.com/greenpeace/planet4-base
+      - INSTALL_APM_AGENT=${INSTALL_APM_AGENT:-false}
       # - MERGE_REF=develop
       # - MERGE_SOURCE=https://github.com/greenpeace/planet4-flibble
       - NEWRELIC_LICENSE=${NEWRELIC_LICENSE:-false}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5963

_Somebody_ forgot to make this PR that was coming with https://github.com/greenpeace/planet4-docker/pull/77 :grin: 

Setting default value to not install APM agent locally gets a bit of installation time back, and avoids cryptic error logs.