### PR TITLE
Fix database import error "mysql has gone away"

### DIFF
--- a/scripts/import-db.sh
+++ b/scripts/import-db.sh
@@ -149,6 +149,7 @@ function import_db() {
   fi
 
   echo "Importing database content from ${DUMP_PATH} ..."
+  mysql_root_exec -e 'SET GLOBAL max_allowed_packet=16777216'
   zcat < "${DUMP_PATH}" | mysql_root_exec_notty "${DB_NAME}"
   # Fix GTID_PURGED value issue
   mysql_root_exec -D "${DB_NAME}" -e 'RESET MASTER'


### PR DESCRIPTION
Importing a DB with large commands throws an error "mysql has gone away" and fails importing the full db.
Current mysql max allowed packet limit is at 4M, raising it to 16M allows to import without errors.

## Test

- Run a DB import for `international` or `aotearoa`
  - `NRO_NAME=international NRO_DB_VERSION=latest make nro-import-db`
  - On master branch , it prints `ERROR 2006 (HY000) at line 572: MySQL server has gone away` and doesn't complete
  - On this branch it finishes properly