### PR TITLE
Switch test install to Japan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       APP_IMAGE: gcr.io/planet-4-151612/wordpress:main
       OPENRESTY_IMAGE: gcr.io/planet-4-151612/planet4-base-openresty:main
       GOOGLE_PROJECT_ID: planet-4-151612
-      NRO_NAME: finland
+      NRO_NAME: japan
       NRO_DB_VERSION: latest
     parameters:
       notify:
@@ -171,7 +171,7 @@ jobs:
       APP_IMAGE: gcr.io/planet-4-151612/wordpress:main
       OPENRESTY_IMAGE: gcr.io/planet-4-151612/planet4-base-openresty:main
       GOOGLE_PROJECT_ID: planet-4-151612
-      NRO_NAME: finland
+      NRO_NAME: japan
       NRO_DB_VERSION: latest
     parameters:
       notify:


### PR DESCRIPTION
The current warning in php container logs comes from a recent change in the Nordic theme (a call to a wordpress function on menus that can happen when menus are not yet available).
Switching from Finland to Japan instance for now fixes the issue.