### PR TITLE
PLANET-6290: Fix admin user email address on local instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -632,7 +632,7 @@ config: check-services
 	docker-compose exec -T php-fpm wp option update rt_wp_nginx_helper_options '$(NGINX_HELPER_JSON)' --format=json
 	docker-compose exec -T php-fpm wp rewrite structure $(REWRITE)
 	docker-compose exec php-fpm wp option patch insert planet4_options cookies_field "Planet4 Cookie Text"
-	docker-compose exec php-fpm wp user update $(WP_ADMIN_USER) --user_pass=$(WP_ADMIN_PASS) --role=administrator
+	docker-compose exec php-fpm wp user update $(WP_ADMIN_USER) --user_email=admin@planet4.test --user_pass=$(WP_ADMIN_PASS) --role=administrator
 	docker-compose exec php-fpm wp plugin deactivate wp-stateless
 	if [[ -z "${ELASTIC_ENABLED}" ]]; then \
 		docker-compose exec php-fpm wp option update ep_host ''


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6290

If an admin user with a greenpeace.org email address exists, admin login to a local instance with debug disabled is impossible, blocked by a forced google login.

## Fix 

Changing the admin user email to a planet4.test domain fixes the issue.

## Test

On a local instance
- Import a database with an existing admin user, disable debug mode
  - `NRO_NAME=netherlands NRO_DB_VERSION=latest make nro-enable`
  - `docker-compose exec php-fpm wp config set WP_DEBUG false --raw`
- Try to login with admin / admin
  - Using `master` branch, login is blocked, asking to use Google auth
  - On this branch, admin login works