### PR TITLE
Fix acceptance test getting stuck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -475,7 +475,7 @@ ci-copyimages: $(LOCAL_IMAGES)
 selenium-run:
 	echo "Starting Selenium"
 	@docker-compose -f docker-compose.full.yml up -d selenium
-	@sleep 3
+	@sleep 15
 
 ## Run tests with Codeception
 test: test-env-info test-codeception


### PR DESCRIPTION
After trying out a few things, it looks like giving a longer sleep for the `selenium` container solves the issue of acceptance tests getting stuck. Unlike the branchname suggests, I did not end up removing coverage collection from the job.

I increased the timeout from 3 to 15. Potentially it needs less, but some seconds margin should ensure it's good for a while.

This branch kept failing until I added a commit to use the code of this PR: https://app.circleci.com/pipelines/github/greenpeace/planet4-master-theme?branch=fix-old-settings-on-new-themes
Last workflow I removed it again, and it again gets stuck.