### PR TITLE
Remove additional selenium run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -475,7 +475,6 @@ ci-copyimages: $(LOCAL_IMAGES)
 selenium-run:
 	echo "Starting Selenium"
 	@docker-compose -f docker-compose.full.yml up -d selenium
-	@sleep 15
 
 ## Run tests with Codeception
 test: test-env-info test-codeception
@@ -515,7 +514,7 @@ test-codeception-acceptance:
 	@docker-compose exec php-fpm tests/vendor/bin/codecept run acceptance --no-redirect --xml=junit.xml --html --coverage --coverage-html coverage_acceptance
 
 .PHONY: test-codeception
-test-codeception: selenium-run test-codeception-acceptance
+test-codeception: test-codeception-acceptance
 
 .PHONY: test-codeception-failed
 test-codeception-failed:


### PR DESCRIPTION
This seems to fix the acceptance tests. However I'm prudent saying that, it's also what I thought with https://github.com/greenpeace/planet4-docker-compose/pull/97, but after merging it turned out to be a lot of coincidence. Or maybe that timeout did decrease the chance a bit. Very weird, since it was always failing before merging, it passed a few times while testing the code. Then after merge it failed every time again :exploding_head: 