### PR TITLE
Fix localdev wp-stateless notice during installation

### DIFF
--- a/scripts/status-report.sh
+++ b/scripts/status-report.sh
@@ -160,11 +160,11 @@ function filter_logs() {
 
   logs=$(docker-compose logs php-fpm 2>/dev/null)
   known_logs=(
-    # Codebase errors (to fix)
-    "PHP Notice:  Undefined index: youtube_id"
     # Warnings during install
     "NOTICE: PHP message: PHP Warning:  Redis::connect(): php_network_getaddresses: getaddrinfo failed"
     "NOTICE: PHP message: PHP Warning:  filectime(): stat failed"
+    # WP-Stateless trying to read an invalid file
+    "NOTICE: PHP message: PHP Notice:  file_get_contents(): read of 8192 bytes failed with errno=21 Is a directory"
     # Warning during NRO install
     "ssmtp: Cannot open smtp:25"
     # Xdebug running without client


### PR DESCRIPTION
Fixing this issue : https://app.circleci.com/pipelines/github/greenpeace/planet4-docker-compose/695/workflows/11806590-d307-4344-9d8d-296417bfe23e/jobs/1609
```
Logs: NOK ✖
  - Unexpected logs found, failing.
php-fpm_1    | [28-Sep-2021 07:46:16] WARNING: [pool www_planet4_test] child 2928 said into stderr: "NOTICE: PHP message: PHP Notice:  file_get_contents(): read of 8192 bytes failed with errno=21 Is a directory in /app/source/public/wp-content/plugins/wp-stateless/lib/classes/class-settings.php on line 236"
```

The local docker-compose configuration leads to docker creating an empty directory (`/app/secrets/wp-stateless-media-key.json/`, locally `./secrets/wp-stateless-media-key.json/`) when no wp-stateless secret file is present.
The plugin tries to read this directory as a config file and emits a notice.
Ignoring this notice for now, as it does not represent an issue for local development.

Also removing a now fixed notice about youtube player.