### PR TITLE
Replace Japan with Africa for NRO test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       APP_IMAGE: gcr.io/planet-4-151612/wordpress:main
       OPENRESTY_IMAGE: gcr.io/planet-4-151612/planet4-base-openresty:main
       GOOGLE_PROJECT_ID: planet-4-151612
-      NRO_NAME: japan
+      NRO_NAME: africa
       NRO_DB_VERSION: latest
     parameters:
       notify:


### PR DESCRIPTION
Seems that Japan's child theme active development often generates unplanned warnings. Switching to a more "stable" NRO.