### PR TITLE
Fix node image version following LTS change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,7 @@ services:
       - "traefik.enable=true"
 
   node:
-    image: ${NODE_IMAGE:-node:lts-alpine}
+    image: ${NODE_IMAGE:-node:14-alpine3.14}
     user: "node"
     tty: true
     networks:


### PR DESCRIPTION
Node [LTS version](https://github.com/nodejs/Release#release-schedule) has been updated, and so the node docker image we use, as it was fixed as `node:lts-alpine`.
This leads to modules [compilation issues](https://app.circleci.com/pipelines/github/greenpeace/planet4-docker-compose/736/workflows/c984a09c-dacb-48e3-9297-0807f6536e99/jobs/1803):
- an error `The package-lock.json file was created with an old version of npm` leads to node trying to rebuild packages with node-gyp, which fails because python is not present in alpine images
- using a debian image with python integrated also fails because of an inadequate python version  
## Fix
Fixing the node image version for now, until we update code to the new LTS version
## Test
- `make deps` should currently fail locally, if you're up to date
  - update docker images `make stop`, run `make pull`, `make run` again
  - verify node and npm version with `docker-compose exec -u node node sh -c 'node --version && npm --version'`, updated versions are `v16.13.0` and `8.1.0 `
- using `NODE_IMAGE=node:14-alpine3.14 make dev-from-release && make deps` works properly
  - versions should be back to `v14.17.3` and `6.14.13`