### PR TITLE
PLANET-6461: Add verifications before install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       APP_IMAGE: gcr.io/planet-4-151612/wordpress:main
       OPENRESTY_IMAGE: gcr.io/planet-4-151612/planet4-base-openresty:main
       GOOGLE_PROJECT_ID: planet-4-151612
-      NRO_NAME: africa
+      NRO_NAME: greenland
       NRO_DB_VERSION: latest
     parameters:
       notify:
@@ -171,7 +171,7 @@ jobs:
       APP_IMAGE: gcr.io/planet-4-151612/wordpress:main
       OPENRESTY_IMAGE: gcr.io/planet-4-151612/planet4-base-openresty:main
       GOOGLE_PROJECT_ID: planet-4-151612
-      NRO_NAME: japan
+      NRO_NAME: greenland
       NRO_DB_VERSION: latest
     parameters:
       notify:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   redis:
-    image: redis:4-stretch
+    image: ${REDIS_IMAGE:-redis:4-stretch}
     networks:
       - local
 

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -23,7 +23,7 @@ services:
       traefik.enable: "true"
 
   redis:
-    image: redis:4-stretch
+    image: ${REDIS_IMAGE:-redis:4-stretch}
     networks:
       - local
     labels:

--- a/docker-compose.stateless.yml
+++ b/docker-compose.stateless.yml
@@ -22,7 +22,7 @@ services:
       traefik.enable: "true"
 
   redis:
-    image: redis:4-stretch
+    image: ${REDIS_IMAGE:-redis:4-stretch}
     networks:
       - local
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       traefik.enable: "true"
 
   redis:
-    image: redis:4-stretch
+    image: ${REDIS_IMAGE:-redis:4-stretch}
     networks:
       - local
     labels:

--- a/scripts/check-existing-content.sh
+++ b/scripts/check-existing-content.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -u
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --env ) ENV="$2"; shift ;;
+    --project ) PROJECT="$2"; shift ;;
+    (--) shift; break ;;
+    (*) break ;;
+  esac
+  shift
+done
+
+ENV=${ENV:-"local"}
+PROJECT=${PROJECT:-"planet4-docker-compose"}
+content_exists=false
+
+echo "Checking content for project ${PROJECT} ..."
+if [[ -n "$(ls -A persistence 2>/dev/null)" ]]; then
+    content_exists=true
+    echo "- Some content is already in the ./persistence folder."
+fi
+if [[ $(docker container ls -a --format '{{.Names}}' | grep -c "^${PROJECT}_") -gt 0 ]]; then
+    content_exists=true
+    echo "- Some containers already exist for this project:"
+    docker container ls -a --filter name="${PROJECT}_" \
+                                            --format 'table {{.ID}}\t{{.Names}}\t{{.Status}}\t{{.CreatedAt}}'
+fi
+if [[ $(docker volume ls --format '{{.Name}}' | grep -c "^${PROJECT}_") -gt 0 ]]; then
+    content_exists=true
+    echo "- Some volumes already exist for this project:"
+    docker volume ls --filter name="${PROJECT}_"
+fi
+if [[ $(docker network ls --format '{{.Name}}' | grep -c "^${PROJECT}_") -gt 0 ]]; then
+    content_exists=true
+    echo "- Some networks already exist for this project:"
+    docker network ls --filter name="${PROJECT}_"
+fi
+if [[ "${ENV}" == "develop" ]] && [[ "${content_exists}" == true ]]; then
+    printf "\n"
+    echo "You should run <make clean> before continuing, as this situation could lead to unexpected results."
+    read -p "Do you still want to continue ? [y/N]: " -n 1 -r continue
+    printf "\n"
+    if [[ "${continue}" != "y" ]] && [[ "${continue}" != "Y" ]]; then
+      printf "Aborting. \n"
+        exit 1
+    fi
+fi
+printf "OK.\n"

--- a/scripts/check-ports-availability.sh
+++ b/scripts/check-ports-availability.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -u
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --env ) ENV="$2"; shift ;;
+    (--) shift; break ;;
+    (*) break ;;
+  esac
+  shift
+done
+
+ENV=${ENV:-"local"}
+OS=$(uname)
+port_taken=false
+
+if [[ "${OS}" == "Darwin" ]]; then
+  web=$(lsof -n -i -P | awk '$10 ~ "LISTEN" && $9 ~ ":80$"')
+  webcache=$(lsof -n -i -P | awk '$10 ~ "LISTEN" && $9 ~ ":8080$"')
+  https=$(lsof -n -i -P | awk '$10 ~ "LISTEN" && $9 ~ ":443$"')
+else
+  web=$(netstat -aln | awk '$6 == "LISTEN" && $4 ~ ":80$"')
+  webcache=$(netstat -aln | awk '$6 == "LISTEN" && $4 ~ ":8080$"')
+  https=$(netstat -aln | awk '$6 == "LISTEN" && $4 ~ ":443$"')
+fi
+
+if [[ -n "${web}" ]]; then
+  port_taken=true
+  echo "Local web port 80 is already in use."
+fi
+if [[ -n "${webcache}" ]]; then
+  port_taken=true
+  echo "Local web port 8080 is already in use."
+fi
+if [[ -n "${https}" ]]; then
+  port_taken=true
+  echo "Local HTTPS port 443 is already in use."
+fi
+if [[ "${ENV}" == "develop" ]] && [[ "${port_taken}" == true ]]; then
+    printf "\n"
+    echo "At least one of the ports used for the application is currently busy."
+    echo "You should stop the applications using those ports (usually an Apache or Nginx instance) before continuing."
+    read -p "Do you still want to continue ? [y/N]: " -n 1 -r continue
+    printf "\n"
+    if [[ "${continue}" != "y" ]] && [[ "${continue}" != "Y" ]]; then
+      printf "Aborting. \n"
+        exit 1
+    fi
+fi

--- a/scripts/clean-content.sh
+++ b/scripts/clean-content.sh
@@ -6,13 +6,13 @@ CONTENT_PATH=${CONTENT_PATH:-defaultcontent}
 if [ -d "${CONTENT_PATH}" ]
 then
   echo
-  echo "Deleting ${CONTENT_PATH} directory ..."
+  echo "Deleting ${CONTENT_PATH} directory content..."
   read -p "Are you sure? [y/N] " -n 1 -r
   if [[ $REPLY =~ ^[Yy]$ ]]
   then
     echo
     set -x >/dev/null
-    rm -fr "${CONTENT_PATH}"
+    rm -fr "${CONTENT_PATH:?}"/*
     set +x >/dev/null
   fi
 fi

--- a/scripts/import-db.sh
+++ b/scripts/import-db.sh
@@ -100,7 +100,7 @@ function find_db() {
   if [[ -n "${DUMP_NAME}" ]]; then
     DUMP_URL=$(gsutil ls -r "gs://${DB_BUCKET}/**/${DUMP_NAME}")
   elif [[ "${DB_VERSION}" == "latest" ]]; then
-    DUMP_URL=$(gsutil ls -rl "gs://${DB_BUCKET}/**" | sort -k2n | \
+    DUMP_URL=$(gsutil ls -rl "gs://${DB_BUCKET}/**" | head -n -1 | sort -k2 | \
                tail -n1 | awk 'END {$1=$2=""; sub(/^[ \t]+/, ""); print }')
   else
     DUMP_PREFIX="planet4-${NRO_NAME}-master-v${DB_VERSION}"


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6461

- __Add detection of docker compose v2__
  V2 is not yet [generally available](https://docs.docker.com/compose/cli-command/#transitioning-to-ga-for-compose-v2), it is sometimes activated automatically on MacOS and fails silently. We'll revise this check once the new compose version is ready.
- __Add detection of ports in use__
  Traefik fails starting if those ports are already in use, but its error comes late and is not obvious.
- __Add Variable for redis image name__
  It's a necessary configuration to run our setup on a new Mac M1.
- __Keep defaultcontent dir on content cleaning__
  Re-installation seems to fail if this folder is missing

Other additions:
- __Extract content detection in a script__
  Too many lines, and shellcheck gives good tips.
- __Fix gsutil dump sort to sort on date column properly__
  Natural sort gives a more accurate result than sorting numerically.
- Switching test NRO to `greenland`, as `africa` hangs a curl request for some reason (not happening locally).

## Tests

### Docker compose V2
On MacOS, open Docker Desktop preferences, check "Use Docker Compose V2"
Run `make check-compose-version`, it should fail with an error message.
Uncheck this option, run  `make check-compose-version` again, you should get no error.

### Port detection
With a running instance, run `make check-ports-availability`.
You should get a prompt telling you ports are in use.

### Keep defaultcontent dir
 Running `make clean` should remove the `defaultcontent` directory content, but not the directory itself

### Fix gsutil dump
You can check the fix manually:
- `gsutil ls -rl "gs://planet4-international-master-db-backup/**" | head -n -1 | sort -k2n` is not sorted properly (2021-11-03 is after 2021-11-18)
- `gsutil ls -rl "gs://planet4-international-master-db-backup/**" | head -n -1 | sort -k2` is following the date column properly.
`head -n -1` is used to filter the last line of `gsutil -l` which gives the total number of objects and size