### PR TITLE
Ignore assets warning on install

### DIFF
--- a/scripts/status-report.sh
+++ b/scripts/status-report.sh
@@ -163,6 +163,8 @@ function filter_logs() {
     # Warnings during install
     "NOTICE: PHP message: PHP Warning:  Redis::connect(): php_network_getaddresses: getaddrinfo failed"
     "NOTICE: PHP message: PHP Warning:  filectime(): stat failed"
+    # Assets not ready, cf https://github.com/greenpeace/planet4-master-theme/pull/1543
+    "NOTICE: PHP message: PHP Notice:  File /app/source/public/wp-content/themes/planet4-master-theme/assets/build/style.min.css does not exist or is not accessible"
     # WP-Stateless trying to read an invalid file
     "NOTICE: PHP message: PHP Notice:  file_get_contents(): read of 8192 bytes failed with errno=21 Is a directory"
     # Warning during NRO install


### PR DESCRIPTION
Fix failing local release build - cf https://app.circleci.com/pipelines/github/greenpeace/planet4-docker-compose/811/workflows/55f0540e-2109-4cc3-9b62-d6e6e980f613/jobs/2065

Since https://github.com/greenpeace/planet4-master-theme/pull/1543 an error is raised if the main css asset is not ready.
This error appears during local installation when the installer calls the local instance [every few seconds](https://github.com/greenpeace/planet4-docker-compose/blob/master/wait.sh#L53) until it's fully built.