### PR TITLE
Fix error on database name generation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[Makefile]
+[{Makefile,Makefile.include}]
 indent_style = tab

--- a/Makefile
+++ b/Makefile
@@ -751,7 +751,7 @@ NRO_APP_HOSTNAME ?= www.planet4.test
 NRO_APP_HOSTPATH ?=
 NRO_IMG_BUCKET ?= planet4-$(NRO_NAME)-stateless
 
-NRO_DATABASE := planet4_$(NRO_NAME)
+NRO_DATABASE ?= $(shell echo "planet4_${NRO_NAME}" | sed 's/-/_/g')
 NRO_DB_PROJECT ?= planet-4-151612
 NRO_DB_BUCKET ?= planet4-$(NRO_NAME)-master-db-backup
 NRO_DB_VERSION ?=


### PR DESCRIPTION
A local install process with a database name based on an nro name with a `-` sign gets the wrong database name and cannot switch to it.

## Test

### Simple name check test
```
NRO_NAME=history-aotearoa make check-nro-config
```
Check the `NRO_DATABASE` value, it shouldn't contain a `-` character.

### Full test
Try installing `history-aotearoa`:
```
NRO_NAME=history-aotearoa NRO_DB_VERSION=latest make nro-from-release
```
Without this fix you'll get errors during install like `Unknown database planet4_history-aotearoa`.

## Additional change
Add Makefile.include to `.editorconfig` as Makefile
