### PR TITLE
Fix wp-stateless key appearing as a directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,6 +394,13 @@ fix-wflogs-permissions:
 secrets:
 	@mkdir $@
 	touch $@/wp-stateless-media-key.json
+
+admin-user:
+	if docker-compose exec php-fpm wp user get $(WP_ADMIN_USER); then \
+		docker-compose exec php-fpm wp user update $(WP_ADMIN_USER) --user_email=admin@planet4.test --user_pass=$(WP_ADMIN_PASS) --role=administrator
+	else \
+		docker-compose exec php-fpm wp user create $(WP_ADMIN_USER) admin@planet4.test --user_pass=$(WP_ADMIN_PASS) --role=administrator
+	fi
 # ============================================================================
 
 # ELASTICSEARCH
@@ -617,7 +624,7 @@ config: check-services
 	docker-compose exec -T php-fpm wp option update rt_wp_nginx_helper_options '$(NGINX_HELPER_JSON)' --format=json
 	docker-compose exec -T php-fpm wp rewrite structure $(REWRITE)
 	docker-compose exec php-fpm wp option patch insert planet4_options cookies_field "Planet4 Cookie Text"
-	docker-compose exec php-fpm wp user update $(WP_ADMIN_USER) --user_email=admin@planet4.test --user_pass=$(WP_ADMIN_PASS) --role=administrator
+	$(MAKE) admin-user
 	docker-compose exec php-fpm wp plugin deactivate wp-stateless
 	if [[ -z "${ELASTIC_ENABLED}" ]]; then \
 		docker-compose exec php-fpm wp option update ep_host ''

--- a/Makefile
+++ b/Makefile
@@ -708,10 +708,13 @@ flush:
 	docker-compose exec php-fpm wp cache flush
 
 ## Enter a shell in the php-fpm container
-.PHONY: php-shell
+.PHONY: php-shell mysql-console
 php-shell:
 	@docker-compose exec php-fpm bash
 
+## Enter mysql console on the current database
+mysql-console:
+	docker-compose exec db mysql -u${MYSQL_USER} -p${MYSQL_PASS} -D $(shell docker-compose exec php-fpm wp config get DB_NAME)
 ## Build master-theme and gutenberg-blocks assets
 .PHONY: assets
 assets:

--- a/Makefile
+++ b/Makefile
@@ -406,13 +406,26 @@ admin-user:
 # ELASTICSEARCH
 
 .PHONY: elastic
-elastic: elastic-index flush
+elastic: elastic-run
 
 elastic-index: check-services
 	@if [[ "${ELASTIC_ENABLED}" != "" ]]; then \
 		docker-compose exec php-fpm wp elasticpress index --setup --quiet --url=www.planet4.test;\
 	fi
 
+elastic-run:
+	@echo "Starting ElasticSearch"
+	docker-compose -f docker-compose.full.yml up -d elasticsearch
+	sleep 5
+	docker-compose exec php-fpm wp option update ep_host $(ELASTICSEARCH_HOST)
+	@echo "Indexing"
+	docker-compose exec php-fpm wp elasticpress index --setup --quiet --url=www.planet4.test
+	$(MAKE) flush
+
+elastic-stop:
+	echo "Stopping ElasticSearch"
+	docker-compose -f docker-compose.full.yml stop elasticsearch
+	docker-compose exec php-fpm wp option update ep_host ''
 # ============================================================================
 
 # CONTINUOUS INTEGRATION TASKS

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ hosts:
 	else echo "Hosts file already configured"; fi
 
 .PHONY: build
-build: hosts run unzipimages config elastic flush
+build: hosts secrets run unzipimages config elastic flush
 
 ## Run containers. Will either start or build them first if they don't exist
 .PHONY: run
@@ -277,7 +277,7 @@ down:
 
 ## Create containers, install developer tools, build assets
 .PHONY: dev
-dev: check-before-install hosts repos run unzipimages config deps elastic flush status
+dev: check-before-install hosts secrets repos run unzipimages config deps elastic flush status
 	@if command -v xattr &> /dev/null; then \
 		$(MAKE) fix-public-permissions; \
 	fi
@@ -391,6 +391,9 @@ fix-app-permissions:
 fix-wflogs-permissions:
 	@chmod -R 777 persistence/app/public/wp-content/wflogs
 
+secrets:
+	@mkdir $@
+	touch $@/wp-stateless-media-key.json
 # ============================================================================
 
 # ELASTICSEARCH
@@ -593,6 +596,7 @@ dev-from-release: $(LOCAL_DEVRELEASE) hosts
 	@tar -xf $(LOCAL_DEVRELEASE)
 	$(MAKE) fix-wflogs-permissions
 	$(MAKE) unzipimages
+	$(MAKE) secrets
 	$(MAKE) run
 	$(MAKE) fix-node-permissions
 	$(MAKE) fix-app-permissions

--- a/scripts/status-report.sh
+++ b/scripts/status-report.sh
@@ -165,8 +165,6 @@ function filter_logs() {
     "NOTICE: PHP message: PHP Warning:  filectime(): stat failed"
     # Assets not ready, cf https://github.com/greenpeace/planet4-master-theme/pull/1543
     "NOTICE: PHP message: PHP Notice:  File /app/source/public/wp-content/themes/planet4-master-theme/assets/build/style.min.css does not exist or is not accessible"
-    # WP-Stateless trying to read an invalid file
-    "NOTICE: PHP message: PHP Notice:  file_get_contents(): read of 8192 bytes failed with errno=21 Is a directory"
     # Warning during NRO install
     "ssmtp: Cannot open smtp:25"
     # Xdebug running without client


### PR DESCRIPTION
## Fixes

- The file `wp-stateless-media-key.json` is mounted automatically even if it does not exist. On a fresh install, this mounts a directory instead of a file, and this directory is not modifiable. Creating an empty file by default solves wp-stateless error `NOTICE: PHP message: PHP Notice:  file_get_contents(): read of 8192 bytes failed with errno=21 Is a directory` on local dev and allows to modify it afterwards.
- New command `make mysql-console` to access mysql console easily
- New command `make admin-user` that can handle creation and update of the user (useful for running NRO instances locally, some have an admin user, some not)
-  Update for elastic command to start elastic server and run indexing

## Tests

- Stop your current env with `make stop`
- Create a new install
```shell
> git clone git@github.com:greenpeace/planet4-docker-compose.git pdc-106
> cd pdc-106
> git checkout fix/wpstateless-key
> make dev
```
- Check that `secrets/wp-stateless-media-key.json` is a file and is editable
- Check that you can log in with admin/admin
- Run `make mysql-console` and then `select database();`, you should see your current database name
- Run `make elastic`, the elastic server should start and index your content