### PR TITLE
Fix status report on missing file wrapper

### DIFF
--- a/scripts/status-report.sh
+++ b/scripts/status-report.sh
@@ -165,6 +165,8 @@ function filter_logs() {
     "NOTICE: PHP message: PHP Warning:  filectime(): stat failed"
     # Assets not ready, cf https://github.com/greenpeace/planet4-master-theme/pull/1543
     "NOTICE: PHP message: PHP Notice:  File /app/source/public/wp-content/themes/planet4-master-theme/assets/build/style.min.css does not exist or is not accessible"
+    # Warning on GS wrapper before wp-stateless is available
+    "NOTICE: PHP message: PHP Warning:  file_exists(): Unable to find the wrapper &quot;gs&quot;"
     # Warning during NRO install
     "ssmtp: Cannot open smtp:25"
     # Xdebug running without client


### PR DESCRIPTION
File access to gs:// files is not available before wp-stateless installation