### PR TITLE
Fix status report on stateless error

### DIFF
--- a/scripts/status-report.sh
+++ b/scripts/status-report.sh
@@ -165,8 +165,9 @@ function filter_logs() {
     "NOTICE: PHP message: PHP Warning:  filectime(): stat failed"
     # Assets not ready, cf https://github.com/greenpeace/planet4-master-theme/pull/1543
     "NOTICE: PHP message: PHP Notice:  File /app/source/public/wp-content/themes/planet4-master-theme/assets/build/style.min.css does not exist or is not accessible"
-    # Warning on GS wrapper before wp-stateless is available
+    # Warning on GS wrapper before wp-stateless is available / after installation
     "NOTICE: PHP message: PHP Warning:  file_exists(): Unable to find the wrapper &quot;gs&quot;"
+    "NOTICE: PHP message: PHP Warning:  chmod(): No such file or directory"
     # Warning during NRO install
     "ssmtp: Cannot open smtp:25"
     # Xdebug running without client


### PR DESCRIPTION
Ref: https://app.circleci.com/pipelines/github/greenpeace/planet4-docker-compose/1008/workflows/82587656-f3e4-4b68-a1eb-0e10431b8d56/jobs/3034
This warning started with wp-stateless update. 

It happens in wp function `wp_mkdir_p()` which stateless uses in `Utility::sync_get_attachment_if_exist()` and `GS_CLient::get_media()`.
I can't replicate it locally, but I don't think it's an issue in this situation.