### PR TITLE
check-compose-version exits incorrectly on valid docker-compose versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,12 +353,14 @@ ifndef ENVSUBST
 	$(error Command: 'envsubst' not found, please install using your package manager)
 endif
 
-# Filter out docker compose V2 until full compatibility
+# Exit if user is using docker-compose version greater than 1.*. 
 check-compose-version:
-	@version=$$(docker-compose --version | grep -Eo '2\.[[:digit:]]{1,3}');
-	if [[ ! -z $${version} ]]; then\
-		echo "You are using docker compose version $${version}, please use version 1.* instead.";\
-		exit 1;\
+	@output=$$(docker-compose --version); \
+	userVersion=$$(echo $$output | grep -o '\d\.\d\+\(.\d\+\)\?'); \
+	unsupportedVersion=$$(echo $$output | grep -o ' [2-9]\.'); \
+	if [[ -n $$unsupportedVersion ]]; then \
+		echo "You are using docker-compose version $$userVersion, which is unsupported. Please use version 1.* instead."; \
+		exit 2; \
 	fi
 
 check-existing-content: envcheck


### PR DESCRIPTION
This PR fixes an issue with `check-compose-version` that causes it to exit incorrectly on valid docker-compose versions, which blocks users from setting up the project.
Fixes https://github.com/greenpeace/planet4-docker-compose/issues/109.

### How to test
 - Go to Makefile and replace this line with a sample output as follows:
```
# Replace this line...
	@output=$$(docker-compose --version); \
	
# ... with a sample output
	@output=$$(echo docker-compose version 1.92.2, build 5becea4c); \
```

 - Run `make check-compose-version` and check that no error message appears, because 1.92.2 is a valid version.
 - Change the version number to other version numbers (2.42.1, 3.99, 1.22.2 etc.), and check that the script exits only on versions greater than 1.*. On master, `make check-compose-version` exits incorrectly for valid version numbers such as 1.92.2. 

